### PR TITLE
docs: clarify coordinate system uses 1:1 mapping, not conversion

### DIFF
--- a/docs/source/how_to/best_practices.md
+++ b/docs/source/how_to/best_practices.md
@@ -15,7 +15,7 @@ Physics engines like Gazebo or Bullet are highly sensitive to how geometry and m
 - **Avoid "Thin" Colliders**: Very thin meshes (like a piece of paper) can cause tunneling errors in physics engines. Give your colliders some thickness.
 
 ### 3. Orientation
-- **X-Forward, Z-Up**: While LinkForge handles coordinate transforms, following the ROS standard (X-axis forward, Y-axis left, Z-axis up) for your links will make joint configuration much more intuitive.
+- **X-Forward, Z-Up**: LinkForge uses **direct 1:1 coordinate mapping** (no automatic rotations). Following the ROS standard (X-axis forward, Y-axis left, Z-axis up) when modeling your robot in Blender will make joint configuration intuitive and match ROS expectations.
 
 ---
 

--- a/docs/source/reference/robot_structure.md
+++ b/docs/source/reference/robot_structure.md
@@ -42,9 +42,17 @@ Joints in LinkForge operate differently than standard Blender parent-child relat
 - This allows LinkForge to build a kinematic tree that stays 100% compliant with URDF, regardless of how objects are organized in the Blender Outliner.
 
 ### 3. Coordinate Systems
-LinkForge handles the conversion between Blender's **Z-Up** system and URDF's **Right-Handed** conventions.
-- **Joint Axes**: Selecting "X", "Y", or "Z" in the Joint panel automatically assigns the correct vector (e.g., `1 0 0`) based on the Joint Empty's orientation.
-- **Origins**: The `location` and `rotation` of the Link Empty in Blender are converted to the `<origin>` tag of its parent Joint.
+Both Blender and URDF use **Z-up, right-handed** coordinate systems. LinkForge uses **direct 1:1 coordinate mapping** (no rotations applied during import/export).
+
+**Coordinate Conventions:**
+- **Blender Default:** Z-up, Y-forward, X-right
+- **URDF/ROS (REP-103):** Z-up, X-forward, Y-left
+
+**Recommendation:** Model your robot using ROS conventions (X-forward) in Blender for intuitive joint configuration, even though Blender's default is Y-forward.
+
+- **Joint Axes**: Selecting "X", "Y", or "Z" in the Joint panel assigns the exact vector (e.g., `1 0 0`) based on the Joint Empty's local orientation.
+- **Origins**: The `location` and `rotation` of Empties in Blender map directly to the `<origin>` tag in URDF (XYZ position, RPY rotation).
+
 
 ## Property Storage
 LinkForge stores all metadata as **Custom Properties** on the Blender objects. These can be inspected in the "Custom Properties" panel of the Object Data tab, though it is recommended to use the LinkForge Sidebar for editing.


### PR DESCRIPTION
# Pull Request

> [!IMPORTANT]
> This project uses **Conventional Commits** and **Release Please** for automated versioning.
> Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat: add lidar sensor`, `fix: core logic bug`).

## 📝 Description
Replace vague statements about "coordinate conversion" and "handling transforms" with accurate descriptions:

- robot_structure.md: Clarify both Blender and URDF use Z-up, right-handed systems with direct 1:1 mapping. Add table showing coordinate conventions.
- best_practices.md: Change "handles coordinate transforms" to "uses direct 1:1 coordinate mapping" to accurately reflect implementation.

## 🛠️ Type of change
- [x] 📚 Documentation (docs)

## ✅ Checklist:
- [ ] I have run `uv run pytest` and all tests pass
- [ ] I have run `uv run pre-commit run --all-files` and all hooks pass
- [ ] I have verified the changes manually in the Blender viewport
- [x] I have updated the documentation or verified no changes are needed
