### PR TITLE
fix: implement data-level mesh cloning for export robustness (#59)

### DIFF
--- a/linkforge/blender/operators/link_ops.py
+++ b/linkforge/blender/operators/link_ops.py
@@ -316,6 +316,10 @@ def _create_primitive_collision(visual_obj, prim_type, link_name, context):
     # This ensures collision has scale=1.0 with geometry at local size
     # When parented to link, it will inherit parent's scale to reach correct world size
     bpy.context.view_layer.objects.active = collision_obj
+
+    # Ensure object is visible for transform_apply operator
+    collision_obj.hide_viewport = False
+
     bpy.ops.object.transform_apply(location=False, rotation=False, scale=True)
 
     # Name it
@@ -348,17 +352,27 @@ def _merge_visual_meshes(visual_objects, context):
     for i, vis in enumerate(visual_objects):
         logger.info(f"  [{i + 1}] {vis.name}")
 
-    # Duplicate all visual objects
+    # Create clones of visual objects using data-level duplication to ensure
+    # robustness against object visibility states in the viewport.
     duplicates = []
     for visual_obj in visual_objects:
-        bpy.ops.object.select_all(action="DESELECT")
-        visual_obj.select_set(True)
-        context.view_layer.objects.active = visual_obj
-        bpy.ops.object.duplicate()
-        dup = context.active_object
+        dup = visual_obj.copy()
+        dup.data = visual_obj.data.copy()
+
+        # Ensure temporary duplicate is visible for join operation
+        dup.hide_viewport = False
+
+        # Link to the same collections as the original
+        for col in visual_obj.users_collection:
+            col.objects.link(dup)
 
         # Clear parent and apply transforms to bake world position into geometry
         dup.parent = None
+
+        # Select and make active for transform application
+        bpy.ops.object.select_all(action="DESELECT")
+        dup.select_set(True)
+        context.view_layer.objects.active = dup
         bpy.ops.object.transform_apply(location=True, rotation=True, scale=True)
 
         duplicates.append(dup)

--- a/linkforge/blender/utils/mesh_export.py
+++ b/linkforge/blender/utils/mesh_export.py
@@ -192,14 +192,17 @@ def create_simplified_mesh(obj: Any, decimation_ratio: float) -> Any | None:
     if obj is None or obj.type != "MESH":
         return None
 
-    # Duplicate the object
-    bpy.ops.object.select_all(action="DESELECT")
-    obj.select_set(True)
-    bpy.context.view_layer.objects.active = obj
-    bpy.ops.object.duplicate()
+    # Use data-level copy instead of high-level duplicate operator to ensure
+    # operation succeeds regardless of viewport visibility (hide_viewport state).
+    simplified_obj = obj.copy()
+    simplified_obj.data = obj.data.copy()
 
-    # Get the duplicated object
-    simplified_obj = bpy.context.active_object
+    # Ensure temporary object is visible for modifier application
+    simplified_obj.hide_viewport = False
+
+    # Link to the same collections as the original
+    for col in obj.users_collection:
+        col.objects.link(simplified_obj)
 
     # Add Decimate modifier
     decimate_mod = simplified_obj.modifiers.new(name="Decimate", type="DECIMATE")
@@ -207,6 +210,8 @@ def create_simplified_mesh(obj: Any, decimation_ratio: float) -> Any | None:
     decimate_mod.decimate_type = "COLLAPSE"
 
     # Apply the modifier
+    bpy.ops.object.select_all(action="DESELECT")
+    simplified_obj.select_set(True)
     bpy.context.view_layer.objects.active = simplified_obj
     bpy.ops.object.modifier_apply(modifier=decimate_mod.name)
 
@@ -313,17 +318,23 @@ def export_link_mesh(
     if dry_run:
         return filepath
 
-    # CRITICAL: Create a temporary duplicate with transforms applied
-    # This ensures the mesh file contains geometry at correct scale but centered at origin
-    # The visual origin in URDF will handle positioning
+    # Create a temporary clone with transforms applied for mesh export.
+    # Data-level copying is used to avoid dependencies on Blender's operator context
+    # and viewport visibility states.
+    temp_export_obj = obj.copy()
+    temp_export_obj.data = obj.data.copy()
 
-    # Select and duplicate the object
+    # Temporarily unhide the duplication (not the original) for transform application
+    temp_export_obj.hide_viewport = False
+
+    # Link to the same collections as the original
+    for col in obj.users_collection:
+        col.objects.link(temp_export_obj)
+
+    # Select and make active for transform application
     bpy.ops.object.select_all(action="DESELECT")
-    obj.select_set(True)
-    bpy.context.view_layer.objects.active = obj
-    bpy.ops.object.duplicate()
-
-    temp_export_obj = bpy.context.active_object
+    temp_export_obj.select_set(True)
+    bpy.context.view_layer.objects.active = temp_export_obj
 
     # CRITICAL FIX: Clear parent to ensure world-space positioning
     # Without this, setting location=(0,0,0) moves to parent's local origin,


### PR DESCRIPTION
# Pull Request

> [!IMPORTANT]
> This project uses **Conventional Commits** and **Release Please** for automated versioning.
> Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat: add lidar sensor`, `fix: core logic bug`).

## 📝 Description
- Replaced `bpy.ops.object.duplicate()` with data-level `obj.copy()` and `obj.data.copy()`
- Decoupled export process from viewport visibility (hide_viewport)
- Improved reliability of mesh simplification and compound collision generation

Fixes #59 

## 🧪 How to Test
1. Import URDF/XACRO file with complex meshes.
2. Generate collisions for any robot link (they will be hidden by default).
3. Export to URDF/XACRO with "Export Meshes" enabled.
4. Result: Export succeeds perfectly without needing to toggle "Show Collision".

## 💻 Environment
- **Blender Version: Blender 4.4.5 LTS
- **Operating System: MacOs M1

## 🛠️ Type of change
- [x] 🐞 Bug fix (fix)

## ✅ Checklist:
- [x] I have run `uv run pytest` and all tests pass
- [x] I have run `uv run pre-commit run --all-files` and all hooks pass
- [x] I have verified the changes manually in the Blender viewport
- [x] I have updated the documentation or verified no changes are needed
