### PR TITLE
feat(core): harden xacro eval sandbox against dunder escapes

### DIFF
--- a/core/src/linkforge_core/parsers/xacro_parser.py
+++ b/core/src/linkforge_core/parsers/xacro_parser.py
@@ -33,6 +33,7 @@ XACRO_URIS = [
     "http://wiki.ros.org/xacro",
 ]
 
+_DUNDER_PATTERN: re.Pattern[str] = re.compile(r"__\w+__")
 
 # Safe math context for evaluations
 MATH_CONTEXT: dict[str, Any] = {
@@ -392,7 +393,7 @@ class XacroResolver:
                 local_props[p_name] = self._try_parse_typed_value(val)
 
             # Expand macro body
-            parent_props = self.properties.copy()
+            parent_props = copy.deepcopy(self.properties)
             self.properties.update(local_props)
 
             container = ET.Element("container")
@@ -541,6 +542,13 @@ class XacroResolver:
 
     def _evaluate(self, expr: str) -> Any:
         """Evaluate a single XACRO expression with hierarchical namespace support."""
+        if _DUNDER_PATTERN.search(expr):
+            raise RobotParserError(
+                f"Expression '{expr}' is not a valid xacro math expression: "
+                "dunder attributes (__class__, __mro__, etc.) are not allowed "
+                "for security reasons."
+            )
+
         try:
             # Build nested context for hierarchical namespaces (e.g. arm.mass)
             ctx = self.eval_context.copy()

--- a/tests/unit/core/test_xacro_security.py
+++ b/tests/unit/core/test_xacro_security.py
@@ -1,0 +1,61 @@
+import pytest
+from linkforge_core.base import RobotParserError
+from linkforge_core.parsers.xacro_parser import XacroResolver
+
+
+class TestXacroEvalSandbox:
+    """Tests to ensure the XACRO eval() sandbox properly blocks malicious code."""
+
+    @pytest.fixture
+    def resolver(self):
+        """Provide a fresh XacroResolver instance for each test."""
+        return XacroResolver()
+
+    def test_allows_safe_math(self, resolver):
+        """Verify that standard mathematical operations are allowed."""
+
+        # Simple arithmetic
+        assert resolver._evaluate("1 + 2 * 3") == 7
+        assert resolver._evaluate("10 / 2.0") == 5.0
+
+        # Math module functions via MATH_CONTEXT
+        assert resolver._evaluate("sin(0)") == 0.0
+        assert resolver._evaluate("cos(pi)") == pytest.approx(-1.0)
+        assert resolver._evaluate("pow(2, 3)") == 8
+
+    def test_blocks_builtins(self, resolver):
+        """Verify that standard Python built-ins like open() are blocked."""
+        with pytest.raises(RobotParserError, match="name 'open' is not defined"):
+            resolver._evaluate("open('/etc/passwd', 'r').read()")
+
+        with pytest.raises(RobotParserError, match="name 'eval' is not defined"):
+            resolver._evaluate("eval('1 + 1')")
+
+        with pytest.raises(RobotParserError, match="name 'exec' is not defined"):
+            resolver._evaluate("exec('x = 1')")
+
+    def test_blocks_dunder_attribute_access(self, resolver):
+        """Verify that dunder attributes (__class__, etc.) are strictly blocked.
+
+        This is the primary mitigation against the well-known eval() sandbox
+        escape vector: `"".__class__.__mro__[1].__subclasses__()`
+        """
+        malicious_payloads = [
+            # Direct class access
+            "''.__class__",
+            "1.__class__",
+            # The full typical exploit chain
+            "''.__class__.__mro__[1].__subclasses__()",
+            # Subclasses method
+            "().__class__.__base__.__subclasses__()",
+            # Globals access
+            "__globals__",
+            # Builtins access
+            "__builtins__",
+            # Import access
+            "__import__('os')",
+        ]
+
+        for payload in malicious_payloads:
+            with pytest.raises(RobotParserError, match="dunder attributes.*are not allowed"):
+                resolver._evaluate(payload)


### PR DESCRIPTION
# Pull Request

> [!IMPORTANT]
> This project uses **Conventional Commits** and **Release Please** for automated versioning.
> Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat: add lidar sensor`, `fix: core logic bug`).

## 📝 Description
This PR hardens the XACRO eval() parser against sandbox escapes (specifically `__class__` traversal) and fixes an issue where macro properties could pollute their outer scope.

## 🛠️ Type of change
- [x] 🚀 New feature (feat)
- [x] 🧪 Tests (test)

## ✅ Checklist
- [x] I have run `uv run pytest` and all tests pass
- [x] I have run `uv run pre-commit run --all-files` and all hooks pass
- [x] I have verified the changes manually in the Blender viewport
- [x] I have updated the documentation or verified no changes are needed
