### PR TITLE
perf: optimize collision quality slider with BMesh and true debounce

### DIFF
--- a/platforms/blender/linkforge/blender/operators/link_ops.py
+++ b/platforms/blender/linkforge/blender/operators/link_ops.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import contextlib
+import time
 import typing
-
-import bpy
-import mathutils
 
 from ...linkforge_core.logging_config import get_logger
 from ..properties.link_props import sanitize_urdf_name
@@ -17,8 +15,16 @@ from ..utils.scene_utils import clear_stats_cache
 if typing.TYPE_CHECKING:
     from bpy.types import Context, Operator
 
+    bpy: typing.Any
+    bmesh: typing.Any
+    mathutils: typing.Any
+
     from ..properties.link_props import LinkPropertyGroup
 else:
+    import bmesh
+    import bpy
+    import mathutils
+
     # Runtime fallback for mock environments where bpy.types might be partially loaded.
     Context = typing.Any
     Operator = getattr(getattr(bpy, "types", object), "Operator", object)
@@ -26,8 +32,8 @@ else:
 logger = get_logger(__name__)
 
 # Global state for debounced collision preview updates
-_preview_update_timer = None
 _preview_pending_object = None
+_preview_last_request_time = 0.0
 
 # Debounce delay for collision preview updates (in seconds)
 COLLISION_PREVIEW_DEBOUNCE_DELAY = 0.3
@@ -37,15 +43,14 @@ def schedule_collision_preview_update(obj: bpy.types.Object) -> None:
     """Schedule a debounced collision preview update.
 
     This prevents excessive regeneration during slider interaction by
-    waiting 0.3 seconds after the last change before updating.
+    waiting 0.3 seconds after the LAST change before updating.
     """
     # pylint: disable=global-statement
-    global _preview_pending_object
+    global _preview_pending_object, _preview_last_request_time
     _preview_pending_object = obj
+    _preview_last_request_time = time.time()
 
     # Register new timer with debounce delay
-    # Note: Multiple timers may be registered, but only the first one to find
-    # _preview_pending_object as not None will execute the update.
     if not bpy.app.timers.is_registered(execute_collision_preview_update):
         bpy.app.timers.register(
             execute_collision_preview_update, first_interval=COLLISION_PREVIEW_DEBOUNCE_DELAY
@@ -56,16 +61,22 @@ def schedule_collision_preview_update(obj: bpy.types.Object) -> None:
 def execute_collision_preview_update() -> None | float:
     """Execute the actual collision mesh update after debounce delay."""
     # pylint: disable=global-statement
-    global _preview_pending_object
+    global _preview_pending_object, _preview_last_request_time
 
     if _preview_pending_object is None:
         return None
 
+    # Implement TRUE debounce: if a new request happened recently, reschedule
+    time_since_last = time.time() - _preview_last_request_time
+    if time_since_last < COLLISION_PREVIEW_DEBOUNCE_DELAY:
+        # Return remaining time to wait
+        return COLLISION_PREVIEW_DEBOUNCE_DELAY - time_since_last
+
     obj = _preview_pending_object
     _preview_pending_object = None
 
-    # Check if object still exists
-    if obj.name not in bpy.data.objects:
+    # Check if object still exists and is in the scene
+    if not obj or obj.name not in bpy.data.objects:
         return None
 
     # Find collision object
@@ -93,7 +104,7 @@ def execute_collision_preview_update() -> None | float:
     collision_type = collision_obj.get("collision_geometry_type", "MESH")
     regenerate_collision_mesh(obj, str(collision_type), bpy.context)
 
-    return None  # Don't repeat timer
+    return None  # All caught up
 
 
 def regenerate_collision_mesh(
@@ -411,14 +422,18 @@ def _create_mesh_collision_compound(
     merged_obj.hide_render = False
 
     # Apply mesh simplification to the merged mesh
-    vl = context.view_layer
-    if vl:
-        vl.objects.active = merged_obj
+    # ensures that BMesh processing is robust regardless of viewport mode.
+    # We use high-performance BMesh API to avoid Object/Edit mode flickering.
+    bm = bmesh.new()
+    bm.from_mesh(typing.cast(bpy.types.Mesh, merged_obj.data))
 
-    bpy.ops.object.mode_set(mode="EDIT")
-    bpy.ops.mesh.select_all(action="SELECT")
-    bpy.ops.mesh.convex_hull()
-    bpy.ops.object.mode_set(mode="OBJECT")
+    # Convex Hull operation (native BMesh API)
+    bmesh.ops.convex_hull(bm, input=bm.verts)
+
+    # Clear original data and load new hull back to mesh data
+    bm.to_mesh(typing.cast(bpy.types.Mesh, merged_obj.data))
+    bm.free()
+    merged_obj.data.update()
 
     # Add decimation modifier for live quality adjustment
     lf = typing.cast("LinkPropertyGroup", getattr(link_obj, "linkforge"))
@@ -1358,9 +1373,17 @@ def update_collision_quality_realtime(
     decimate_mod = next((m for m in collision_obj.modifiers if m.type == "DECIMATE"), None)
     if decimate_mod and isinstance(decimate_mod, bpy.types.DecimateModifier):
         decimate_mod.ratio = quality_ratio
+    elif collision_obj.type == "MESH":
+        # FALLBACK IMPROVEMENT: If modifier is missing but object exists, try adding it first
+        # This is much faster than full _regenerate_ and avoids one potential "jump".
+        decimate_mod = typing.cast(
+            bpy.types.DecimateModifier,
+            collision_obj.modifiers.new(name="Decimate", type="DECIMATE"),
+        )
+        decimate_mod.ratio = quality_ratio
+        decimate_mod.decimate_type = "COLLAPSE"
     else:
-        # FALLBACK: If the modifier was deleted or missing, schedule a full regeneration.
-        # This is safe and ensures the user always sees the correct result.
+        # ABSOLUTE FALLBACK: schedule a full regeneration for primitives or missing objects.
         schedule_collision_preview_update(obj)
 
 

--- a/platforms/blender/linkforge/blender/properties/link_props.py
+++ b/platforms/blender/linkforge/blender/properties/link_props.py
@@ -85,6 +85,7 @@ def set_link_name(self: LinkPropertyGroup, value: str) -> None:
     clear_stats_cache()
 
 
+@typing.no_type_check
 def on_collision_quality_update(self: bpy.types.PropertyGroup, context: Context) -> None:
     """Update collision mesh preview when quality changes.
 
@@ -104,8 +105,8 @@ def on_collision_quality_update(self: bpy.types.PropertyGroup, context: Context)
     if collision_obj is None:
         return
 
-    # Skip regeneration for imported URDF models to preserve external data
-    if "imported_from_urdf" in collision_obj:  # type: ignore[operator]
+    # Skip regeneration for imported URDF models to preserve ext
+    if collision_obj.get("imported_from_urdf", False):
         return
 
     # Update ratio in realtime

--- a/tests/unit/platforms/blender/test_collision_quality_live.py
+++ b/tests/unit/platforms/blender/test_collision_quality_live.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import bpy
 import pytest
 from linkforge.blender.operators.link_ops import (
@@ -63,10 +61,11 @@ def test_update_collision_quality_realtime_fallback() -> None:
     bpy.ops.object.select_all(action="SELECT")
     bpy.ops.object.delete()
 
-    # Setup link and collision but DELETE the modifier manually
+    # Setup link and collision without modifier
     bpy.ops.mesh.primitive_monkey_add()
     bpy.ops.linkforge.create_link_from_mesh()
     link_obj = bpy.context.active_object
+    link_obj.linkforge.collision_quality = 20.0
 
     create_collision_for_link(link_obj, "MESH", bpy.context)
     collision_obj = next(c for c in link_obj.children if "_collision" in c.name)
@@ -74,10 +73,9 @@ def test_update_collision_quality_realtime_fallback() -> None:
     # Remove all modifiers
     collision_obj.modifiers.clear()
 
-    with patch(
-        "linkforge.blender.operators.link_ops.schedule_collision_preview_update"
-    ) as mock_schedule:
-        update_collision_quality_realtime(link_obj, collision_obj)
+    update_collision_quality_realtime(link_obj, collision_obj)
 
-        # VERIFY: Scheduled a full update since modifier was missing
-        mock_schedule.assert_called_once_with(link_obj)
+    # Verify modifier restoration (Fast Path)
+    decimate_mod = next((m for m in collision_obj.modifiers if m.type == "DECIMATE"), None)
+    assert decimate_mod is not None
+    assert decimate_mod.ratio == pytest.approx(0.2)

--- a/tests/unit/platforms/blender/test_link_ops.py
+++ b/tests/unit/platforms/blender/test_link_ops.py
@@ -270,8 +270,13 @@ def test_add_material_slot() -> None:
 
 def test_schedule_collision_preview() -> None:
     """Test that collision preview update is scheduled via timer."""
+    # Setup test scene
+    bpy.ops.object.select_all(action="SELECT")
+    bpy.ops.object.delete()
+    bpy.ops.mesh.primitive_cube_add()
+    obj = bpy.context.active_object
+
     with patch("bpy.app.timers.register") as mock_register:
-        obj = MagicMock()
         schedule_collision_preview_update(obj)
 
     mock_register.assert_called_once()
@@ -285,41 +290,49 @@ def test_execute_collision_preview_no_obj() -> None:
     """Test that preview update handles missing pending object."""
     from linkforge.blender.operators import link_ops
 
+    # 1. Pending object is None
     link_ops._preview_pending_object = None
-    result = execute_collision_preview_update()
-    assert result is None
+    link_ops._preview_last_request_time = 0.0  # Reset
+    assert execute_collision_preview_update() is None
 
-    # Patch the entire bpy reference in the module to avoid read-only issues
-    mock_bpy = MagicMock()
-    mock_bpy.data.objects.__contains__.return_value = False
-    with patch("linkforge.blender.operators.link_ops.bpy", mock_bpy):
-        result = execute_collision_preview_update()
-        assert result is None
+    # 2. Pending object exists but is not in bpy.data.objects (deleted)
+    obj = bpy.data.objects.new("DeletedObj", None)
+    link_ops._preview_pending_object = obj
+    # Object is not linked to any collection, so it won't be in bpy.data.objects.
+    # Note: bpy.data.objects only contains linked/registered objects.
+    assert execute_collision_preview_update() is None
 
 
 def test_execute_collision_preview_complex_scenarios() -> None:
-    """Test execute_collision_preview_update with various states."""
+    """Test execute_collision_preview_update with various real-world states."""
     from linkforge.blender.operators import link_ops
 
+    bpy.ops.object.select_all(action="SELECT")
+    bpy.ops.object.delete()
+
     # 1. No collision object found
-    obj = MagicMock()
-    obj.name = "test_obj"
-    obj.children = []
+    obj = bpy.data.objects.new("test_obj", None)
+    bpy.context.collection.objects.link(obj)
     link_ops._preview_pending_object = obj
+    link_ops._preview_last_request_time = 0.0  # Force update
 
-    mock_bpy = MagicMock()
-    mock_bpy.data.objects.__contains__.return_value = True
-    mock_bpy.data.objects.__getitem__.return_value = obj
-    with patch("linkforge.blender.operators.link_ops.bpy", mock_bpy):
-        assert execute_collision_preview_update() is None
-
-    # 2. No view layer
-    col = MagicMock()
-    col.name = "test_collision"
-    obj.children = [col]
-    # Re-patch bpy but without view_layer
-    mock_bpy.context.view_layer = None
     assert execute_collision_preview_update() is None
+
+    # 2. No view layer (Simulation of missing context)
+    mesh = bpy.data.meshes.new("col_mesh")
+    col = bpy.data.objects.new("test_obj_collision", mesh)
+    bpy.context.collection.objects.link(col)
+    col.parent = obj
+
+    with patch("linkforge.blender.operators.link_ops.bpy") as mock_bpy:
+        # Simulate missing view_layer context
+        mock_bpy.data = bpy.data
+        mock_bpy.context = MagicMock()
+        mock_bpy.context.view_layer = None
+
+        link_ops._preview_pending_object = obj
+        link_ops._preview_last_request_time = 0.0
+        assert execute_collision_preview_update() is None
 
 
 def test_create_collision_for_link_multi_visual() -> None:
@@ -613,20 +626,38 @@ def test_inertia_extraction_failure() -> None:
 
 def test_link_ops_debounced_preview_logic() -> None:
     """Hit all error paths in execute_collision_preview_update."""
-    with patch("linkforge.blender.operators.link_ops._preview_pending_object", None):
-        assert execute_collision_preview_update() is None
+    with (
+        patch("linkforge.blender.operators.link_ops._preview_pending_object", None),
+        patch("linkforge.blender.operators.link_ops.time.time", return_value=1234567890.0),
+        patch("linkforge.blender.operators.link_ops._preview_last_request_time", 0.0),
+    ):
+        from linkforge.blender.operators import link_ops
+
+        assert link_ops.execute_collision_preview_update() is None
 
     link_obj = bpy.data.objects.new("TestLink_Preview", None)
     bpy.context.collection.objects.link(link_obj)
     link_obj.linkforge.is_robot_link = True
 
-    with patch("linkforge.blender.operators.link_ops._preview_pending_object", link_obj):
-        assert execute_collision_preview_update() is None
+    with (
+        patch("linkforge.blender.operators.link_ops._preview_pending_object", link_obj),
+        patch("linkforge.blender.operators.link_ops.time.time", return_value=1234567890.0),
+        patch("linkforge.blender.operators.link_ops._preview_last_request_time", 0.0),
+    ):
+        from linkforge.blender.operators import link_ops
+
+        assert link_ops.execute_collision_preview_update() is None
 
     mock_obj = MagicMock()
     mock_obj.name = "DeletedObject"
-    with patch("linkforge.blender.operators.link_ops._preview_pending_object", mock_obj):
-        assert execute_collision_preview_update() is None
+    with (
+        patch("linkforge.blender.operators.link_ops._preview_pending_object", mock_obj),
+        patch("linkforge.blender.operators.link_ops.time.time", return_value=1234567890.0),
+        patch("linkforge.blender.operators.link_ops._preview_last_request_time", 0.0),
+    ):
+        from linkforge.blender.operators import link_ops
+
+        assert link_ops.execute_collision_preview_update() is None
 
     mesh = bpy.data.meshes.new("sphere_mesh")
     sphere_obj = bpy.data.objects.new("TestLink_Preview_collision", mesh)
@@ -783,3 +814,46 @@ def test_link_ops_low_level_edge_cases_extended() -> None:
     bad_vis.parent = link_obj
 
     assert _merge_visual_meshes([bad_vis], link_obj, bpy.context) is None
+
+
+def test_update_collision_quality_realtime() -> None:
+    """Test the realtime collision quality update (fast path)."""
+    from linkforge.blender.operators.link_ops import update_collision_quality_realtime
+
+    bpy.ops.object.select_all(action="SELECT")
+    bpy.ops.object.delete()
+
+    # Setup: Link and Collision Object
+    bpy.ops.linkforge.add_empty_link()
+    link_obj = bpy.context.active_object
+    link_obj.linkforge.collision_quality = 50.0
+
+    mesh = bpy.data.meshes.new("sphere_mesh")
+    collision_obj = bpy.data.objects.new("Link_collision", mesh)
+    bpy.context.collection.objects.link(collision_obj)
+    collision_obj.parent = link_obj
+
+    # 1. Test Fallback (No modifier, type MESH -> Should add modifier)
+    assert len(collision_obj.modifiers) == 0
+    update_collision_quality_realtime(link_obj, collision_obj)
+
+    decimate_mod = next((m for m in collision_obj.modifiers if m.type == "DECIMATE"), None)
+    assert decimate_mod is not None
+    assert decimate_mod.ratio == 0.5
+
+    # 2. Test Fast Path (Update existing modifier)
+    link_obj.linkforge.collision_quality = 25.0
+    update_collision_quality_realtime(link_obj, collision_obj)
+    assert decimate_mod.ratio == 0.25
+
+    # 3. Test Fallback (Non-mesh -> Should schedule full update)
+    # Use an Empty object as the collision object (type is EMPTY)
+    empty_col = bpy.data.objects.new("Empty_collision", None)
+    bpy.context.collection.objects.link(empty_col)
+    empty_col.parent = link_obj
+
+    with patch(
+        "linkforge.blender.operators.link_ops.schedule_collision_preview_update"
+    ) as mock_schedule:
+        update_collision_quality_realtime(link_obj, empty_col)
+        mock_schedule.assert_called_once_with(link_obj)

--- a/tests/unit/platforms/blender/test_link_ops_robustness.py
+++ b/tests/unit/platforms/blender/test_link_ops_robustness.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import bpy
 import pytest
@@ -22,17 +22,22 @@ def test_execute_collision_preview_update_branches(clean_scene) -> None:
 
     # No view_layer
     with patch("linkforge.blender.operators.link_ops.bpy") as mock_bpy:
-        mock_bpy.data.objects = {"Link": link_obj}
+        # Simulate missing view_layer context
+        mock_bpy.data = bpy.data
+        mock_bpy.context = MagicMock()
         mock_bpy.context.view_layer = None
+
         # We need to set the global _preview_pending_object
         import linkforge.blender.operators.link_ops as link_ops
 
         link_ops._preview_pending_object = link_obj
+        link_ops._preview_last_request_time = 0.0
         assert execute_collision_preview_update() is None
 
     # imported_from_urdf
     col_obj["imported_from_urdf"] = True
     link_ops._preview_pending_object = link_obj
+    link_ops._preview_last_request_time = 0.0
     assert execute_collision_preview_update() is None
     col_obj["imported_from_urdf"] = False
 


### PR DESCRIPTION
## 📝 Description
- Replace mode-switching bpy.ops.mesh.convex_hull with BMesh API
- Implement timestamp-based debounce for fallback updates
- Add fast path restoration for missing Decimate modifiers
- Update unit tests to mock time and global state
- Fix type-checking guards for Blender modules
- Remove dead code (unused timer variables)

## 🛠️ Type of change
- [x] 🐞 Bug fix (fix)
- [x] 🧪 Tests (test)
- [x] 🧹 Refactor (refactor)

## ✅ Checklist
- [x] I have run `uv run pytest` and all tests pass
- [x] I have run `uv run pre-commit run --all-files` and all hooks pass
- [x] I have verified the changes manually in the Blender viewport
- [x] I have updated the documentation or verified no changes are needed
