### PR TITLE
feat: ROS XACRO Parity and Blender 5.x (Python 3.13) Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout code

--- a/Justfile
+++ b/Justfile
@@ -14,6 +14,10 @@ build: build-blender
 build-blender:
     uv run python platforms/blender/scripts/build.py
 
+# Sync Blender dependencies (downloads platform-specific wheels)
+sync:
+    uv run python platforms/blender/scripts/build.py sync
+
 # --- Test ---
 
 # Run all tests (Core + Blender)

--- a/core/src/linkforge_core/models/geometry.py
+++ b/core/src/linkforge_core/models/geometry.py
@@ -140,9 +140,9 @@ class Mesh:
 
     def __post_init__(self) -> None:
         """Validate mesh scale."""
-        if self.scale.x <= 0 or self.scale.y <= 0 or self.scale.z <= 0:
+        if self.scale.x == 0 or self.scale.y == 0 or self.scale.z == 0:
             raise RobotModelError(
-                f"Mesh scale must be positive, got scale=({self.scale.x}, {self.scale.y}, {self.scale.z})"
+                f"Mesh scale components must be non-zero, got scale=({self.scale.x}, {self.scale.y}, {self.scale.z})"
             )
 
     @property

--- a/core/src/linkforge_core/parsers/xacro_parser.py
+++ b/core/src/linkforge_core/parsers/xacro_parser.py
@@ -17,11 +17,15 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
-import yaml  # type: ignore
+try:
+    import yaml  # type: ignore[import-untyped]
+except ImportError:
+    yaml = None
 
 from ..base import RobotParser, RobotParserError
 from ..logging_config import get_logger
 from ..models.robot import Robot
+from ..utils.dict_utils import AttrDict
 from ..utils.path_utils import resolve_package_path
 
 logger = get_logger(__name__)
@@ -53,6 +57,9 @@ MATH_CONTEXT["__builtins__"] = {
     "dict": dict,
     "bool": bool,
 }
+# Standard XACRO booleans
+MATH_CONTEXT["true"] = True
+MATH_CONTEXT["false"] = False
 
 
 class XacroResolver:
@@ -84,16 +91,17 @@ class XacroResolver:
             set()
         )  # Track active block insertions to prevent infinite recursion
 
-        # Per-instance evaluation context to allow file-aware data loading
+        # Shared evaluation context (load functions and standard arg)
         self.eval_context = MATH_CONTEXT.copy()
-        # Add 'load_yaml' and 'load_json' for top-level use
         self.eval_context["load_yaml"] = self._handle_load_yaml
         self.eval_context["load_json"] = self._handle_load_json
+        self.eval_context["arg"] = self._handle_arg_eval
 
-        # Add 'xacro' namespace for ROS-standard compliance (e.g. xacro.load_yaml)
+        # ROS-standard 'xacro' namespace
         xacro_ns = SimpleNamespace()
         xacro_ns.load_yaml = self._handle_load_yaml
         xacro_ns.load_json = self._handle_load_json
+        xacro_ns.arg = self._handle_arg_eval
         xacro_ns.warning = logger.warning
         xacro_ns.error = logger.error
         xacro_ns.fatal = logger.critical
@@ -595,7 +603,7 @@ class XacroResolver:
             return False
         else:
             try:
-                # Basic string/bool comparison with math/data support
+                # Standard expression evaluation
                 if _DUNDER_PATTERN.search(condition_str):
                     raise RobotParserError(
                         f"Condition '{condition_str}' contains forbidden dunder attributes."
@@ -618,14 +626,15 @@ class XacroResolver:
             return value
 
         # Try YAML (most robust and standard compliant)
-        try:
-            # safe_load handles ints, floats, bools (true/false), nulls, lists, dicts
-            parsed = yaml.safe_load(value)
-            # If it's a primitive type or collection, use it.
-            if isinstance(parsed, (int, float, bool, list, dict)) or parsed is None:
-                return parsed
-        except Exception:
-            pass
+        if yaml is not None:
+            try:
+                # safe_load handles ints, floats, bools (true/false), nulls, lists, dicts
+                parsed = yaml.safe_load(value)
+                # If it's a primitive type or collection, use it.
+                if isinstance(parsed, (int, float, bool, list, dict)) or parsed is None:
+                    return AttrDict._wrap(parsed)
+            except Exception:
+                pass
 
         # Fallback manual parsing (in case yaml fails or returns string for number)
         try:
@@ -668,7 +677,11 @@ class XacroResolver:
 
         text = re.sub(r"\$\(arg (.*?)\)", _resolve_arg, text)
 
-        # 2. Handle environment variable substitution, matching roslaunch behaviour.
+        # 2. Handle evaluation: $(eval expression) - Standard ROS XACRO feature
+        # We treat it as an alias for ${...} since our evaluation engine is Python-based.
+        text = re.sub(r"\$\(eval (.*?)\)", r"${\1}", text)
+
+        # 3. Handle environment variable substitution, matching roslaunch behaviour.
         # $(env VAR) raises if unset; $(optenv VAR) returns ""; $(optenv VAR default) returns default.
         def _resolve_env(m: re.Match[str]) -> str:
             parts = m.group(1).split(None, 1)
@@ -763,6 +776,17 @@ class XacroResolver:
             # we must tell the user immediately rather than producing a corrupt URDF.
             raise RobotParserError(f"Failed to evaluate expression '${{{expr}}}': {e}") from e
 
+    def _handle_arg_eval(self, name: str) -> Any:
+        """Access XACRO arguments in evaluation context.
+
+        Args:
+            name: Name of the argument to retrieve.
+
+        Returns:
+            The argument value if found, otherwise an empty string.
+        """
+        return self.args.get(name, "")
+
     def _handle_load_yaml(self, filename: str) -> Any:
         """Helper to load YAML file in XACRO context.
 
@@ -782,10 +806,11 @@ class XacroResolver:
             return {}
         try:
             with open(path) as f:
-                return yaml.safe_load(f)
+                data = yaml.safe_load(f)
+                return AttrDict._wrap(data)
         except Exception as e:  # pragma: no cover
             logger.error(f"XACRO: Failed to load YAML {filename}: {e}")
-            return {}
+            return AttrDict()
 
     def _handle_load_json(self, filename: str) -> Any:
         """Helper to load JSON file in XACRO context.
@@ -805,10 +830,11 @@ class XacroResolver:
             return {}
         try:
             with open(path) as f:
-                return json.load(f)
+                data = json.load(f)
+                return AttrDict._wrap(data)
         except Exception as e:  # pragma: no cover
             logger.error(f"XACRO: Failed to load JSON {filename}: {e}")
-            return {}
+            return AttrDict()
 
     def _finalize_urdf(self, root: ET.Element) -> str:
         """Strip XACRO artifacts and format the final XML.

--- a/core/src/linkforge_core/utils/dict_utils.py
+++ b/core/src/linkforge_core/utils/dict_utils.py
@@ -1,0 +1,82 @@
+"""Dictionary utility functions for LinkForge."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class AttrDict(dict[str, Any]):
+    """Dictionary providing attribute-access for nested fields (e.g., config.mass).
+    Used for XACRO property resolution where YAML-loaded data uses dot notation.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the attribute dictionary and recursively wrap nested data.
+
+        Args:
+            *args: Positional arguments passed to the dict constructor.
+            **kwargs: Keyword arguments passed to the dict constructor.
+        """
+        super().__init__(*args, **kwargs)
+        for key, value in self.items():
+            self[key] = self._wrap(value)
+
+    @classmethod
+    def _wrap(cls, value: Any) -> Any:
+        """Recursively wrap dictionaries and lists.
+
+        Args:
+            value: The value to potentially wrap in an AttrDict.
+
+        Returns:
+            The wrapped value (AttrDict, list of wrapped values, or the original).
+        """
+        if isinstance(value, dict):
+            return cls(value)
+        if isinstance(value, list):
+            return [cls._wrap(v) for v in value]
+        return value
+
+    def __getattr__(self, name: str) -> Any:
+        """Access dictionary keys as attributes.
+
+        Args:
+            name: Key name to access.
+
+        Returns:
+            Value associated with the key.
+
+        Raises:
+            AttributeError: If key is not found.
+        """
+        try:
+            return self[name]
+        except KeyError:
+            raise AttributeError(
+                f"'{self.__class__.__name__}' object has no attribute '{name}'"
+            ) from None
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Set dictionary keys as attributes.
+
+        Args:
+            name: Key name to set.
+            value: Value to associate with the key.
+        """
+        self[name] = value
+
+    def __delattr__(self, name: str) -> None:
+        """Delete dictionary keys as attributes.
+
+        Args:
+            name: Key name to delete.
+
+        Raises:
+            AttributeError: If key is not found.
+        """
+        try:
+            del self[name]
+        except KeyError:
+            raise AttributeError(
+                f"'{self.__class__.__name__}' object has no attribute '{name}'"
+            ) from None

--- a/platforms/blender/blender_manifest.toml
+++ b/platforms/blender/blender_manifest.toml
@@ -61,6 +61,14 @@ wheels = [
     "./wheels/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl",
     "./wheels/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
     "./wheels/pyyaml-6.0.3-cp311-cp311-win_amd64.whl",
+    "./wheels/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl",
+    "./wheels/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl",
+    "./wheels/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+    "./wheels/pyyaml-6.0.3-cp312-cp312-win_amd64.whl",
+    "./wheels/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl",
+    "./wheels/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl",
+    "./wheels/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+    "./wheels/pyyaml-6.0.3-cp313-cp313-win_amd64.whl",
 ]
 # END AUTOMATED WHEELS
 

--- a/platforms/blender/linkforge/blender/operators/import_ops.py
+++ b/platforms/blender/linkforge/blender/operators/import_ops.py
@@ -185,6 +185,15 @@ class LINKFORGE_OT_import_urdf(Operator, ImportHelper):  # type: ignore[misc]
             logger.exception("Import process crashed")
             return {"CANCELLED"}
 
+        # Detect macro-only files (empty robots)
+        if not robot.links and not robot.joints:
+            self.report(
+                {"WARNING"},
+                f"The file '{urdf_path.name}' contains no links or joints. "
+                "It may be a macro-only XACRO file. Please import the top-level robot description instead.",
+            )
+            return {"CANCELLED"}
+
         # Validate robot structure
         from ...linkforge_core.validation import RobotValidator
 

--- a/platforms/blender/scripts/build.py
+++ b/platforms/blender/scripts/build.py
@@ -45,7 +45,7 @@ DEP_CONFIG: dict[str, dict[str, typing.Any]] = {
             "macosx_10_13_x86_64",
             "manylinux2014_x86_64",
         ],
-        "py_versions": ["311"],  # Blender 4.2+
+        "py_versions": ["311", "312", "313"],  # Blender 4.2, 5.0, 5.1+
     }
 }
 
@@ -86,8 +86,10 @@ def sync_dependencies() -> None:
             # Download pure-python universal wheel
             subprocess.run(
                 [
-                    sys.executable,
-                    "-m",
+                    "uv",
+                    "run",
+                    "--with",
+                    "pip",
                     "pip",
                     "download",
                     req,
@@ -103,8 +105,10 @@ def sync_dependencies() -> None:
                 for py_ver in config["py_versions"]:
                     subprocess.run(
                         [
-                            sys.executable,
-                            "-m",
+                            "uv",
+                            "run",
+                            "--with",
+                            "pip",
                             "pip",
                             "download",
                             req,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,22 +52,34 @@ ignore = ["E501", "B008", "C901", "B009", "N801"]
 "__init__.py" = ["F401"]
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.13"
 strict = true
 warn_return_any = true
 warn_unused_configs = true
+mypy_path = ["core/src", "platforms/blender"]
 
 # Blender (bpy) stubs use Python 3.12 syntax.
-# We set the parser to 3.12 above and skip deep inspection here.
 [[tool.mypy.overrides]]
-module = "bpy.*"
+module = [
+    "bpy",
+    "bpy.*",
+    "mathutils",
+    "mathutils.*",
+    "gpu",
+    "gpu.*",
+    "gpu_extras",
+    "gpu_extras.*",
+    "bpy_extras",
+    "bpy_extras.*",
+]
 ignore_errors = true
 ignore_missing_imports = true
-
 # Enable full type checking for all LinkForge Blender modules
 [[tool.mypy.overrides]]
 module = "linkforge.blender.*"
 ignore_errors = false
+disallow_subclassing_any = false
+warn_unused_ignores = false
 
 # Tiered Quality Control: Strict enforcement for production core, optimized for developer velocity in test suites.
 [[tool.mypy.overrides]]

--- a/tests/integration/core/test_urdf_parser.py
+++ b/tests/integration/core/test_urdf_parser.py
@@ -236,12 +236,13 @@ class TestParseGeometry:
         assert geom is None
         assert "Invalid mesh geometry ignored" in caplog.text
 
-    def test_parse_mesh_negative_scale(self, parser, caplog) -> None:
-        """Test that mesh with negative scale returns None and logs warning."""
+    def test_parse_mesh_negative_scale(self, parser) -> None:
+        """Test that mesh with negative scale (mirroring) is accepted."""
         elem = ET.fromstring('<geometry><mesh filename="test.stl" scale="1 -1 1"/></geometry>')
         geom = parser._parse_geometry_element(elem)
-        assert geom is None
-        assert "Invalid mesh geometry ignored" in caplog.text
+
+        assert isinstance(geom, Mesh)
+        assert geom.scale.y == pytest.approx(-1.0)
 
     def test_parse_cylinder_invalid_radius(self, parser, caplog) -> None:
         """Test that cylinder with invalid radius format returns None and logs warning."""

--- a/tests/integration/core/test_xacro_standard_features.py
+++ b/tests/integration/core/test_xacro_standard_features.py
@@ -1,0 +1,87 @@
+import tempfile
+from pathlib import Path
+
+from linkforge_core.parsers.xacro_parser import XACROParser
+
+
+def test_xacro_standard_parities() -> None:
+    """Verify standard ROS XACRO parity including $(eval) and recursive dot-access.
+
+    Checks compliance using synthetic XACRO and YAML structures without
+    relying on external file dependencies.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        config_dir = tmp_path / "config"
+        urdf_dir = tmp_path / "urdf"
+        config_dir.mkdir()
+        urdf_dir.mkdir()
+
+        # 1. Create a nested YAML config
+        yaml_content = """
+kinematics:
+  base:
+    x: 0.1
+    y: 0.2
+    z: 0.3
+    roll: 1.5707
+  arm:
+    link1:
+      length: 0.5
+      mass: 2.0
+"""
+        yaml_file = config_dir / "kinematics.yaml"
+        yaml_file.write_text(yaml_content)
+
+        # 2. Create a XACRO file using dot-access and $(eval)
+        xacro_content = f"""<?xml version="1.0"?>
+<robot name="compat_robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:arg name="use_eval" default="true"/>
+  <xacro:property name="kin" value="${{load_yaml('{yaml_file}')}}"/>
+
+  <link name="base_link">
+    <visual>
+      <origin xyz="$(eval kin.kinematics.base.x) ${{kin.kinematics.base.y}} 0" rpy="${{kin.kinematics.base.roll}} 0 0"/>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+    </visual>
+  </link>
+
+  <xacro:if value="$(arg use_eval)">
+    <link name="arm_link">
+      <inertial>
+        <mass value="${{kin.kinematics.arm.link1.mass}}"/>
+        <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+      </inertial>
+    </link>
+
+    <joint name="base_to_arm" type="fixed">
+      <parent link="base_link"/>
+      <child link="arm_link"/>
+      <origin xyz="0 0 $(eval kin.kinematics.arm.link1.length / 2.0)"/>
+    </joint>
+  </xacro:if>
+</robot>
+"""
+        xacro_file = urdf_dir / "robot.xacro"
+        xacro_file.write_text(xacro_content)
+
+        # 3. Resolve and verify
+        parser = XACROParser()
+        robot = parser.parse(xacro_file)
+
+        assert robot.name == "compat_robot"
+        assert len(robot.links) == 2
+        assert len(robot.joints) == 1
+
+        # Verify dot-access resolution in attributes
+        next(link for link in robot.links if link.name == "base_link")
+
+        arm_link = next(link for link in robot.links if link.name == "arm_link")
+        assert arm_link.inertial.mass == 2.0
+
+        joint = robot.joints[0]
+        # origin z: "$(eval kin.kinematics.arm.link1.length / 2.0)" -> 0.5 / 2.0 = 0.25
+        assert joint.origin.xyz.z == 0.25
+        assert joint.origin.xyz.x == 0.0

--- a/tests/unit/core/test_geometry.py
+++ b/tests/unit/core/test_geometry.py
@@ -179,12 +179,12 @@ class TestMesh:
         mesh = Mesh(resource="model.stl")
         assert mesh.type == GeometryType.MESH
 
-    def test_negative_scale_validation(self) -> None:
-        """Test that negative scale is rejected."""
-        with pytest.raises(RobotModelError, match="Mesh scale must be positive"):
-            Mesh(resource="model.stl", scale=Vector3(-1.0, 1.0, 1.0))
+    def test_negative_scale_support(self) -> None:
+        """Test that negative scale is now accepted for mirroring."""
+        mesh = Mesh(resource="model.stl", scale=Vector3(-1.0, 1.0, 1.0))
+        assert mesh.scale.x == -1.0
 
     def test_zero_scale_validation(self) -> None:
         """Test that zero scale is rejected."""
-        with pytest.raises(RobotModelError, match="Mesh scale must be positive"):
+        with pytest.raises(RobotModelError, match="Mesh scale components must be non-zero"):
             Mesh(resource="model.stl", scale=Vector3(1.0, 0.0, 1.0))

--- a/tests/unit/core/test_urdf_parser.py
+++ b/tests/unit/core/test_urdf_parser.py
@@ -862,11 +862,6 @@ class TestURDFParser:
         elem = ET.fromstring(xml)
         assert parser._parse_geometry_element(elem) is None
 
-        # Negative scale
-        xml = '<geometry><mesh filename="test.stl" scale="-1 1 1" /></geometry>'
-        elem = ET.fromstring(xml)
-        assert parser._parse_geometry_element(elem) is None
-
         # Cylinder invalid length
         xml = '<geometry><cylinder radius="1" length="-1"/></geometry>'
         assert parser._parse_geometry_element(ET.fromstring(xml)) is None
@@ -875,9 +870,11 @@ class TestURDFParser:
         xml = "<geometry><mesh/></geometry>"
         assert parser._parse_geometry_element(ET.fromstring(xml)) is None
 
-        # Mesh negative scale
+        # Mesh negative scale (Mirroring support)
         xml = '<geometry><mesh filename="f.stl" scale="-1 1 1"/></geometry>'
-        assert parser._parse_geometry_element(ET.fromstring(xml)) is None
+        geom = parser._parse_geometry_element(ET.fromstring(xml))
+        assert isinstance(geom, Mesh)
+        assert geom.scale.x == -1.0
 
         # 3. Material Errors
         # Invalid RGBA length

--- a/tests/unit/core/test_xacro_parser.py
+++ b/tests/unit/core/test_xacro_parser.py
@@ -58,6 +58,30 @@ def test_substitute_resolves_arguments() -> None:
     assert resolver._substitute("package://$(arg pkg_name)/meshes") == "package://my_robot/meshes"
 
 
+def test_xacro_eval_arg_function() -> None:
+    """Verify that arg('name') function is available in evaluations."""
+    resolver = XacroResolver()
+    resolver.args["pkg_name"] = "my_robot"
+    assert resolver._evaluate("arg('pkg_name')") == "my_robot"
+    assert resolver._evaluate("arg('nonexistent')") == ""
+
+
+def test_xacro_substitute_eval() -> None:
+    """Verify that $(eval ...) is supported as an alias for ${...}."""
+    resolver = XacroResolver()
+    resolver.args["mode"] = "fast"
+    resolver.properties["mass"] = 10.0
+
+    # Basic eval
+    assert resolver._substitute("$(eval 1 + 1)") == 2
+    # Eval with args
+    assert resolver._substitute("$(eval mode == 'fast')") is True
+    # Eval with properties
+    assert resolver._substitute("$(eval mass * 2)") == 20.0
+    # Nested in string
+    assert resolver._substitute("Value is $(eval 10 + 5) units") == "Value is 15 units"
+
+
 def test_resolve_elements_with_conditionals() -> None:
     resolver = XacroResolver()
 
@@ -506,6 +530,26 @@ def test_xacro_load_yaml(tmp_path) -> None:
     link = next(c for c in resolved if c.tag == "link")
     assert link.get("name") == "bot"
     assert link.get("mass") == "10.5"
+
+
+def test_xacro_load_yaml_with_dot_access(tmp_path) -> None:
+    """Verify that YAML data supports dot notation for property access."""
+    yaml_path = tmp_path / "config.yaml"
+    yaml_path.write_text("links:\n  base:\n    mass: 5.0\n    name: robot_base")
+
+    main_xml = ET.fromstring(f"""
+        <root xmlns:xacro="http://www.ros.org/wiki/xacro">
+            <xacro:property name="config" value="${{load_yaml('{str(yaml_path)}')}}"/>
+            <link name="${{config.links.base.name}}" mass="${{config.links.base.mass}}"/>
+        </root>
+    """)
+
+    resolver = XacroResolver()
+    resolved = resolver.resolve_element(main_xml)
+
+    link = next(c for c in resolved if c.tag == "link")
+    assert link.get("name") == "robot_base"
+    assert link.get("mass") == "5.0"
 
 
 def test_xacro_load_json(tmp_path) -> None:

--- a/tests/unit/platforms/blender/test_import_ops.py
+++ b/tests/unit/platforms/blender/test_import_ops.py
@@ -15,7 +15,7 @@ def test_import_urdf_logic_paths(tmp_path) -> None:
     mock_self.report = MagicMock()
 
     urdf_file = tmp_path / "test.urdf"
-    urdf_file.write_text("<robot name='test'/>")
+    urdf_file.write_text("<robot name='test'><link name='base_link'/></robot>")
     mock_self.filepath = str(urdf_file)
 
     context = MagicMock()
@@ -90,7 +90,7 @@ def test_import_urdf_directory_handling_more(tmp_path) -> None:
 
     # Case 1: Exactly one valid file
     robot_file = subdir / "one.urdf"
-    robot_file.write_text("<robot name='one'/>")
+    robot_file.write_text("<robot name='one'><link name='base_link'/></robot>")
     mock_self.filepath = str(subdir)
 
     with (
@@ -115,7 +115,7 @@ def test_import_urdf_directory_candidates(tmp_path) -> None:
     subdir.mkdir()
     # Create a candidate file (matching robot.urdf pattern)
     robot_file = subdir / "robot.urdf"
-    robot_file.write_text("<robot name='pkg'/>")
+    robot_file.write_text("<robot name='pkg'><link name='base_link'/></robot>")
     mock_self.filepath = str(subdir)
 
     with (


### PR DESCRIPTION
## 📝 Description
- Complete ROS XACRO parity with  support and dot-notation property access
- Implement negative mesh scale support for mirror transformations
- Improve packaging with soft-import for PyYAML and binary wheels for Python 3.11-3.13

- Fixes #195 
- Fixes #196 

## 🛠️ Type of change
- [x] 🚀 New feature (feat)
- [x] 🐞 Bug fix (fix)
- [x] 🧪 Tests (test)

## ✅ Checklist
- [x] I have run `uv run pytest` and all tests pass
- [x] I have run `uv run pre-commit run --all-files` and all hooks pass
- [x] I have verified the changes manually in the Blender viewport
- [x] I have updated the documentation or verified no changes are needed
