### PR TITLE
fix(build): shorten blender manifest tagline to respect 64 character limit

### DIFF
--- a/platforms/blender/src/linkforge/blender/blender_manifest.toml
+++ b/platforms/blender/src/linkforge/blender/blender_manifest.toml
@@ -12,8 +12,8 @@ version = "1.3.0" # x-release-please-version
 # Display name shown in Blender
 name = "LinkForge"
 
-# Short description (tagline) - max ~100 characters
-tagline = "Visual Designer for LinkForge: Build, validate, and export URDF/XACRO robot models"
+# Short description (tagline) - max 64 characters
+tagline = "Visual Designer to build and export URDF/XACRO robot models"
 
 # Extension type
 type = "add-on"


### PR DESCRIPTION

## 📝 Description
shorten blender manifest tagline to respect 64 character limit