### PR TITLE
fix(blender): resolve primitive bounding box centers and joint rotation doubling

### DIFF
--- a/docs/source/how_to/best_practices.md
+++ b/docs/source/how_to/best_practices.md
@@ -16,6 +16,7 @@ Physics engines like Gazebo or Bullet are highly sensitive to how geometry and m
 
 ### 3. Orientation
 - **X-Forward, Z-Up**: LinkForge uses **direct 1:1 coordinate mapping** (no automatic rotations). Following the ROS standard (X-axis forward, Y-axis left, Z-axis up) when modeling your robot in Blender will make joint configuration intuitive and match ROS expectations.
+- **Root Base Link Origin**: To comply with URDF kinematics standards, LinkForge automatically treats the root base link as the center of the local coordinate system `(0, 0, 0)`. Any global translation or rotation applied to the root base link in Blender will be stripped upon export. You should position your robot wherever it is easiest to model in Blender, and spawn it at the desired world coordinates dynamically inside your simulator (e.g., Gazebo or Godot).
 
 ---
 

--- a/docs/source/how_to/best_practices.md
+++ b/docs/source/how_to/best_practices.md
@@ -16,7 +16,7 @@ Physics engines like Gazebo or Bullet are highly sensitive to how geometry and m
 
 ### 3. Orientation
 - **X-Forward, Z-Up**: LinkForge uses **direct 1:1 coordinate mapping** (no automatic rotations). Following the ROS standard (X-axis forward, Y-axis left, Z-axis up) when modeling your robot in Blender will make joint configuration intuitive and match ROS expectations.
-- **Root Base Link Origin**: To comply with URDF kinematics standards, LinkForge automatically treats the root base link as the center of the local coordinate system `(0, 0, 0)`. Any global translation or rotation applied to the root base link in Blender will be stripped upon export. You should position your robot wherever it is easiest to model in Blender, and spawn it at the desired world coordinates dynamically inside your simulator (e.g., Gazebo or Godot).
+- **Root Base Link Origin**: To comply with URDF kinematics standards, LinkForge automatically treats the root base link as the center of the local coordinate system `(0, 0, 0)`. Any global translation or rotation applied to the root base link in Blender will be stripped upon export. You should position your robot wherever it is easiest to model in Blender, and spawn it at the desired world coordinates dynamically inside your simulator.
 
 ---
 

--- a/docs/source/reference/blender_properties_schema.md
+++ b/docs/source/reference/blender_properties_schema.md
@@ -1,81 +1,92 @@
 # Blender Properties Schema
 
 LinkForge stores all robot data as structured Blender custom properties on scene objects.
-This page documents the full schema for all property groups, their keys, types, and default
-values.
+This page is the authoritative reference for every property key, its type, and its default value.
 
-This schema is the stable foundation of LinkForge. External tools (e.g. Godot, Unity, custom
-pipelines) can access this data by enabling **Custom Properties** in Blender's glTF exporter
-(`File → Export → glTF 2.0 → Data → Custom Properties`), which embeds all properties as
-JSON metadata inside the `.glb` file.
+## Why This Matters — Using LinkForge Data in External Tools
+
+Because all LinkForge data is stored as standard Blender custom properties, you can export it
+to any glTF-compatible tool (Godot, Unity, custom pipelines) **without writing a URDF importer**:
+
+1. In Blender, go to **File → Export → glTF 2.0**.
+2. Under **Data**, enable **Custom Properties**.
+3. All LinkForge robot data (mass, joints, limits, sensors…) will be embedded as JSON metadata
+   inside the `.glb` file and readable in Godot via `node.get_meta("linkforge")`.
 
 ```{important}
-These property keys are considered **stable**. They will not be renamed without a major
-version bump and a clear migration note in the [CHANGELOG](../CHANGELOG.md).
+These property keys are **stable**. They will not be renamed without a major version bump and
+a migration note in the [CHANGELOG](../CHANGELOG.md).
 ```
 
 ---
 
 ## Property Group Keys
 
-Each property group is attached to a Blender `Object` under a fixed attribute name:
+Each group is registered on `bpy.types.Object` under a fixed attribute name.
+When exported to glTF, this attribute name becomes the JSON metadata key.
 
-| Attribute on `bpy.types.Object` | Applies To | Purpose |
+| glTF Metadata Key | Blender Object Type | Purpose |
 |---|---|---|
-| `linkforge` | Link Empty | Robot link physics and identification |
-| `linkforge_joint` | Joint Empty | Joint kinematics and limits |
-| `linkforge_sensor` | Sensor Empty | Sensor configuration |
-| `linkforge_transmission` | Joint Empty | ROS 2 transmission data |
-| `linkforge_control` | Robot root | ROS 2 Control hardware interface |
+| `linkforge` | Link Empty | Link identification, physics, inertia |
+| `linkforge_joint` | Joint Empty (ARROWS) | Joint type, axis, limits, mimic |
+| `linkforge_sensor` | Sensor Empty | Camera, LIDAR, IMU, GPS, Contact, FT |
+| `linkforge_transmission` | Transmission Empty | ROS 2 transmission / gear ratios |
+
+> **Note:** `linkforge_control` and `linkforge_robot` are stored on the **Scene**, not on
+> individual objects. They are not exported to glTF Custom Properties.
 
 ---
 
 ## `linkforge` — Link Properties
 
-Stored on **Link Empty** objects (parent of visual/collision meshes).
+Stored on **Link Empty** objects (the parent empty of visual and collision meshes).
 
 ### Identification
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `is_robot_link` | `bool` | `false` | Marks this object as a robot link |
-| `source_name_stored` | `str` | `""` | Persistent robot-model name (immune to Blender `.001` suffixing) |
+| `is_robot_link` | `bool` | `false` | `true` if this object is a robot link |
+| `source_name_stored` | `str` | `""` | Stable robot-model name, immune to Blender `.001` suffixing |
 
 ### Physics
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `mass` | `float` | `1.0` | Mass in kilograms |
-| `use_auto_inertia` | `bool` | `true` | Auto-calculate inertia from geometry |
-| `inertia_ixx` | `float` | `1.0` | Moment of inertia around X axis (kg·m²) |
-| `inertia_iyy` | `float` | `1.0` | Moment of inertia around Y axis (kg·m²) |
-| `inertia_izz` | `float` | `1.0` | Moment of inertia around Z axis (kg·m²) |
-| `inertia_ixy` | `float` | `0.0` | Product of inertia XY (kg·m²) |
-| `inertia_ixz` | `float` | `0.0` | Product of inertia XZ (kg·m²) |
-| `inertia_iyz` | `float` | `0.0` | Product of inertia YZ (kg·m²) |
-| `inertia_origin_xyz` | `float[3]` | `[0,0,0]` | Center of mass offset (meters) |
-| `inertia_origin_rpy` | `float[3]` | `[0,0,0]` | Center of mass rotation (radians, XYZ) |
+| `mass` | `float` | `1.0` | Link mass in kilograms |
+| `use_auto_inertia` | `bool` | `true` | When `true`, inertia is computed from geometry automatically |
+| `inertia_ixx` | `float` | `1.0` | Moment of inertia — X axis (kg·m²) |
+| `inertia_iyy` | `float` | `1.0` | Moment of inertia — Y axis (kg·m²) |
+| `inertia_izz` | `float` | `1.0` | Moment of inertia — Z axis (kg·m²) |
+| `inertia_ixy` | `float` | `0.0` | Cross product of inertia XY (kg·m²) |
+| `inertia_ixz` | `float` | `0.0` | Cross product of inertia XZ (kg·m²) |
+| `inertia_iyz` | `float` | `0.0` | Cross product of inertia YZ (kg·m²) |
+| `inertia_origin_xyz` | `float[3]` | `[0, 0, 0]` | Center-of-mass position offset from link frame (meters) |
+| `inertia_origin_rpy` | `float[3]` | `[0, 0, 0]` | Center-of-mass orientation from link frame (radians, XYZ Euler) |
+
+> **Tip:** `inertia_ixx / iyy / izz` are only read by LinkForge when `use_auto_inertia` is `false`.
 
 ### Collision
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `collision_type` | `str` (enum) | `"auto"` | Collision shape: `"auto"`, `"box"`, `"sphere"`, `"cylinder"`, `"mesh"` |
-| `collision_quality` | `float` | `50.0` | Mesh simplification percentage (1–100%) |
+| `collision_type` | `str` | `"auto"` | Collision shape. One of: `"auto"`, `"box"`, `"sphere"`, `"cylinder"`, `"mesh"` |
+| `collision_quality` | `float` | `50.0` | Mesh simplification level (1–100%). Only used when `collision_type` is `"mesh"` |
 
 ### Material
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `use_material` | `bool` | `false` | Export Blender material color to URDF |
+| `use_material` | `bool` | `false` | When `true`, exports the Blender material color as a URDF `<material>` tag |
 
 ### Advanced Simulation (Gazebo)
 
+Only exported when `use_simulation_props` is `true`.
+
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `use_simulation_props` | `bool` | `false` | Include Gazebo-specific simulation properties |
-| `self_collide` | `bool` | `false` | Allow self-collision with other links |
-| `gravity` | `bool` | `true` | Affected by gravity |
+| `use_simulation_props` | `bool` | `false` | Enable Gazebo-specific `<gazebo>` tag export |
+| `gravity` | `bool` | `true` | Whether this link is affected by gravity |
+| `self_collide` | `bool` | `false` | Whether this link collides with other links in the same robot |
 | `mu` | `float` | `1.0` | Static (Coulomb) friction coefficient |
 | `mu2` | `float` | `1.0` | Dynamic friction coefficient |
 | `kp` | `float` | `1e12` | Contact stiffness (N/m) |
@@ -85,53 +96,75 @@ Stored on **Link Empty** objects (parent of visual/collision meshes).
 
 ## `linkforge_joint` — Joint Properties
 
-Stored on **Joint Empty** objects (colored ARROWS empties).
+Stored on **Joint Empty** objects (ARROWS empties with colored axes).
 
 ### Identification
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `is_robot_joint` | `bool` | `false` | Marks this object as a robot joint |
-| `source_name_stored` | `str` | `""` | Persistent robot-model name |
+| `is_robot_joint` | `bool` | `false` | `true` if this object is a robot joint |
+| `source_name_stored` | `str` | `""` | Stable robot-model name, immune to Blender `.001` suffixing |
 
 ### Kinematics
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `joint_type` | `str` (enum) | `"revolute"` | `"revolute"`, `"continuous"`, `"prismatic"`, `"fixed"`, `"floating"`, `"planar"` |
-| `parent_link` | `Object ref` | `None` | The parent link object |
-| `child_link` | `Object ref` | `None` | The child link object |
-| `axis` | `str` (enum) | `"Z"` | Joint motion axis: `"X"`, `"Y"`, `"Z"`, `"CUSTOM"` |
-| `custom_axis_x` | `float` | `0.0` | Custom axis X component (normalized) |
-| `custom_axis_y` | `float` | `0.0` | Custom axis Y component (normalized) |
-| `custom_axis_z` | `float` | `1.0` | Custom axis Z component (normalized) |
+| `joint_type` | `str` | `"revolute"` | One of: `"revolute"`, `"continuous"`, `"prismatic"`, `"fixed"`, `"floating"`, `"planar"` |
+| `parent_link` | `Object pointer` | `None` | Reference to the parent link object |
+| `child_link` | `Object pointer` | `None` | Reference to the child link object |
+| `axis` | `str` | `"Z"` | Motion axis. One of: `"X"`, `"Y"`, `"Z"`, `"CUSTOM"` |
+| `custom_axis_x` | `float` | `0.0` | Custom axis X component (auto-normalized to unit vector) |
+| `custom_axis_y` | `float` | `0.0` | Custom axis Y component (auto-normalized to unit vector) |
+| `custom_axis_z` | `float` | `1.0` | Custom axis Z component (auto-normalized to unit vector) |
+
+> **Note:** `custom_axis_*` are only read when `axis` is `"CUSTOM"`.
 
 ### Limits
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `use_limits` | `bool` | `false` | Enable position limits |
-| `limit_lower` | `float` | `-π` | Lower position limit (rad or m) |
-| `limit_upper` | `float` | `+π` | Upper position limit (rad or m) |
-| `limit_effort` | `float` | `10.0` | Maximum force/torque (N or N·m) |
-| `limit_velocity` | `float` | `1.0` | Maximum velocity (rad/s or m/s) |
+| `use_limits` | `bool` | `false` | Enable joint position limits |
+| `limit_lower` | `float` | `-3.14159` | Lower position limit — radians for revolute/continuous, meters for prismatic |
+| `limit_upper` | `float` | `+3.14159` | Upper position limit — radians for revolute/continuous, meters for prismatic |
+| `limit_effort` | `float` | `10.0` | Maximum force or torque the actuator can apply (N or N·m) |
+| `limit_velocity` | `float` | `1.0` | Maximum joint velocity (rad/s or m/s) |
 
 ### Dynamics
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `use_dynamics` | `bool` | `false` | Enable friction/damping |
-| `dynamics_damping` | `float` | `0.0` | Resistance to motion |
-| `dynamics_friction` | `float` | `0.0` | Static friction |
+| `use_dynamics` | `bool` | `false` | Include dynamics in the exported URDF |
+| `dynamics_damping` | `float` | `0.0` | Viscous damping — resistance to motion |
+| `dynamics_friction` | `float` | `0.0` | Static friction — resistance to starting motion |
 
 ### Mimic
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `use_mimic` | `bool` | `false` | Copy another joint's movement |
-| `mimic_joint` | `Object ref` | `None` | Joint to copy from |
-| `mimic_multiplier` | `float` | `1.0` | Movement scale factor |
-| `mimic_offset` | `float` | `0.0` | Position offset after multiplier |
+| `use_mimic` | `bool` | `false` | When `true`, this joint copies another joint's movement |
+| `mimic_joint` | `Object pointer` | `None` | The joint to copy movement from |
+| `mimic_multiplier` | `float` | `1.0` | Scale factor applied to the mimic joint's position |
+| `mimic_offset` | `float` | `0.0` | Constant offset added after applying the multiplier |
+
+### Safety Controller
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `use_safety_controller` | `bool` | `false` | Include a safety controller in the exported URDF |
+| `safety_soft_lower_limit` | `float` | `0.0` | Soft lower position bound |
+| `safety_soft_upper_limit` | `float` | `0.0` | Soft upper position bound |
+| `safety_k_position` | `float` | `0.0` | Position gain for the safety controller |
+| `safety_k_velocity` | `float` | `0.0` | Velocity gain for the safety controller |
+
+### Calibration
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `use_calibration` | `bool` | `false` | Include joint calibration data in the exported URDF |
+| `use_calibration_rising` | `bool` | `false` | Include a rising-edge reference position |
+| `calibration_rising` | `float` | `0.0` | Rising-edge reference position (when enabled) |
+| `use_calibration_falling` | `bool` | `false` | Include a falling-edge reference position |
+| `calibration_falling` | `float` | `0.0` | Falling-edge reference position (when enabled) |
 
 ---
 
@@ -139,68 +172,106 @@ Stored on **Joint Empty** objects (colored ARROWS empties).
 
 Stored on **Sensor Empty** objects.
 
-### Identification
+### Identification & Common
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `is_robot_sensor` | `bool` | `false` | Marks this object as a robot sensor |
-| `source_name_stored` | `str` | `""` | Persistent robot-model name |
-| `sensor_type` | `str` (enum) | `"camera"` | `"camera"`, `"depth_camera"`, `"lidar"`, `"gpu_lidar"`, `"imu"`, `"gps"`, `"contact"`, `"force_torque"` |
-| `attached_link` | `Object ref` | `None` | The link this sensor is mounted on |
-
-### Common
-
-| Key | Type | Default | Description |
-|---|---|---|---|
-| `update_rate` | `float` | `30.0` | Sensor update frequency (Hz) |
-| `always_on` | `bool` | `true` | Keep sensor active at all times |
-| `visualize` | `bool` | `false` | Visualize sensor in simulator |
-| `topic_name` | `str` | `""` | ROS topic name for sensor data |
+| `is_robot_sensor` | `bool` | `false` | `true` if this object is a robot sensor |
+| `source_name_stored` | `str` | `""` | Stable robot-model name |
+| `sensor_type` | `str` | `"camera"` | One of: `"camera"`, `"depth_camera"`, `"lidar"`, `"gpu_lidar"`, `"imu"`, `"gps"`, `"contact"`, `"force_torque"` |
+| `attached_link` | `Object pointer` | `None` | The link this sensor is physically mounted on |
+| `update_rate` | `float` | `30.0` | Data output frequency (Hz) |
+| `always_on` | `bool` | `true` | Keep the sensor active even when the robot is idle |
+| `visualize` | `bool` | `false` | Render sensor geometry in the simulator viewport |
+| `topic_name` | `str` | `""` | ROS 2 topic name for the sensor data stream |
 
 ### Camera / Depth Camera
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `camera_horizontal_fov` | `float` | `1.047` | Horizontal field of view (radians) |
-| `camera_width` | `int` | `640` | Image width (pixels) |
-| `camera_height` | `int` | `480` | Image height (pixels) |
-| `camera_near_clip` | `float` | `0.1` | Near clipping distance (m) |
-| `camera_far_clip` | `float` | `100.0` | Far clipping distance (m) |
-| `camera_format` | `str` (enum) | `"R8G8B8"` | Pixel format |
+| `camera_horizontal_fov` | `float` | `1.047` | Horizontal field of view in radians (≈ 60°) |
+| `camera_width` | `int` | `640` | Image width in pixels |
+| `camera_height` | `int` | `480` | Image height in pixels |
+| `camera_near_clip` | `float` | `0.1` | Near clipping distance (meters) |
+| `camera_far_clip` | `float` | `100.0` | Far clipping distance (meters) |
+| `camera_format` | `str` | `"R8G8B8"` | Pixel format. One of: `"R8G8B8"`, `"R16G16B16"`, `"L8"`, `"L16"`, `"BAYER_RGGB8"`, `"BAYER_BGGR8"` |
 
 ### LIDAR / GPU LIDAR
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `lidar_horizontal_samples` | `int` | `360` | Horizontal scan samples |
-| `lidar_horizontal_min_angle` | `float` | `-π` | Min horizontal angle (radians) |
-| `lidar_horizontal_max_angle` | `float` | `+π` | Max horizontal angle (radians) |
-| `lidar_vertical_samples` | `int` | `1` | Vertical scan samples (1 = 2D) |
-| `lidar_vertical_min_angle` | `float` | `0.0` | Min vertical angle (radians) |
-| `lidar_vertical_max_angle` | `float` | `0.0` | Max vertical angle (radians) |
-| `lidar_range_min` | `float` | `0.08` | Minimum range (m) |
-| `lidar_range_max` | `float` | `10.0` | Maximum range (m) |
-| `lidar_range_resolution` | `float` | `0.01` | Range resolution (m) |
+| `lidar_horizontal_samples` | `int` | `360` | Number of horizontal scan rays |
+| `lidar_horizontal_min_angle` | `float` | `-3.14159` | Start angle of the horizontal scan (radians) |
+| `lidar_horizontal_max_angle` | `float` | `+3.14159` | End angle of the horizontal scan (radians) |
+| `lidar_vertical_samples` | `int` | `1` | Number of vertical scan layers (set to `1` for 2D LIDAR) |
+| `lidar_vertical_min_angle` | `float` | `0.0` | Start angle of the vertical scan (radians) |
+| `lidar_vertical_max_angle` | `float` | `0.0` | End angle of the vertical scan (radians) |
+| `lidar_range_min` | `float` | `0.08` | Minimum detectable range (meters) |
+| `lidar_range_max` | `float` | `10.0` | Maximum detectable range (meters) |
+| `lidar_range_resolution` | `float` | `0.01` | Range measurement precision (meters) |
 
-### Noise
+### Contact Sensor
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `use_noise` | `bool` | `false` | Add noise model to sensor output |
-| `noise_type` | `str` (enum) | `"gaussian"` | `"gaussian"` or `"gaussian_quantized"` |
-| `noise_mean` | `float` | `0.0` | Noise mean |
-| `noise_stddev` | `float` | `0.0` | Noise standard deviation |
+| `contact_collision` | `str` | `""` | Collision element name to monitor. Defaults to `<linkname>_collision` if empty |
+
+### Noise Model
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `use_noise` | `bool` | `false` | Add a noise model to simulate realistic sensor imprecision |
+| `noise_type` | `str` | `"gaussian"` | Noise distribution. One of: `"gaussian"`, `"gaussian_quantized"` |
+| `noise_mean` | `float` | `0.0` | Mean of the noise distribution |
+| `noise_stddev` | `float` | `0.0` | Standard deviation of the noise distribution |
+
+### Gazebo Plugin
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `use_gazebo_plugin` | `bool` | `false` | Attach a Gazebo plugin to this sensor |
+| `plugin_filename` | `str` | `""` | Plugin `.so` filename (e.g. `libgazebo_ros_camera.so`) |
 
 ---
 
-## Raw ID Properties (Mesh children)
+## `linkforge_transmission` — Transmission Properties
 
-These are plain Blender ID properties (not PropertyGroups) set directly on visual and
-collision mesh objects using `object["key"] = value`:
+Stored on **Transmission Empty** objects. Used for ROS 2 `<transmission>` tags.
+
+### Identification
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `is_robot_transmission` | `bool` | `false` | `true` if this object is a robot transmission |
+| `source_name_stored` | `str` | `""` | Stable robot-model name |
+| `transmission_type` | `str` | `"simple"` | One of: `"simple"`, `"differential"`, `"four_bar_linkage"`, `"custom"` |
+| `custom_type` | `str` | `""` | Custom type identifier (only used when `transmission_type` is `"custom"`) |
+
+### Joints & Actuators
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `joint_name` | `Object pointer` | `None` | Controlled joint (for `"simple"` transmissions) |
+| `joint1_name` | `Object pointer` | `None` | First joint (for `"differential"` transmissions) |
+| `joint2_name` | `Object pointer` | `None` | Second joint (for `"differential"` transmissions) |
+| `hardware_interface` | `str` | `"position"` | ROS 2 Control interface. One of: `"position"`, `"velocity"`, `"effort"` |
+| `mechanical_reduction` | `float` | `1.0` | Gear reduction ratio (actuator / joint) |
+| `offset` | `float` | `0.0` | Joint position offset (radians or meters) |
+| `use_custom_actuator_name` | `bool` | `false` | Use a manually specified actuator name |
+| `actuator_name` | `str` | `""` | Actuator name (when `use_custom_actuator_name` is `true`) |
+| `actuator1_name` | `str` | `""` | First actuator name (for `"differential"` transmissions) |
+| `actuator2_name` | `str` | `""` | Second actuator name (for `"differential"` transmissions) |
+
+---
+
+## Raw ID Properties (Visual & Collision Mesh Children)
+
+These are plain Blender ID properties set directly on child mesh objects
+using `object["key"] = value`. They are visible in glTF exports as metadata.
 
 | Key | Type | Description |
 |---|---|---|
-| `collision_geometry_type` | `str` | Shape type: `"box"`, `"sphere"`, `"cylinder"`, `"mesh"` |
-| `imported_from_source` | `bool` | `true` if object was created by importing a URDF |
-| `source_geometry_type` | `str` | Original geometry type from imported URDF |
-| `source_name` | `str` | Original name from imported URDF |
+| `collision_geometry_type` | `str` | Resolved shape: `"box"`, `"sphere"`, `"cylinder"`, or `"mesh"` |
+| `imported_from_source` | `bool` | `true` if this object was created by importing a URDF |
+| `source_geometry_type` | `str` | Original geometry type from the imported URDF |
+| `source_name` | `str` | Original object name from the imported URDF |

--- a/docs/source/reference/blender_properties_schema.md
+++ b/docs/source/reference/blender_properties_schema.md
@@ -3,15 +3,21 @@
 LinkForge stores all robot data as structured Blender custom properties on scene objects.
 This page is the authoritative reference for every property key, its type, and its default value.
 
-## Why This Matters — Using LinkForge Data in External Tools
+## Using LinkForge Data in External Tools
 
-Because all LinkForge data is stored as standard Blender custom properties, you can export it
-to any glTF-compatible tool (Godot, Unity, custom pipelines) **without writing a URDF importer**:
+Because all LinkForge data is stored as standard Blender custom properties, any tool that
+supports **glTF 2.0 Custom Properties** can read it — game engines (Godot, Unity, Unreal),
+web renderers (Three.js, Babylon.js), or any custom C++/Python pipeline — **without needing
+a URDF parser**.
 
-1. In Blender, go to **File → Export → glTF 2.0**.
-2. Under **Data**, enable **Custom Properties**.
-3. All LinkForge robot data (mass, joints, limits, sensors…) will be embedded as JSON metadata
-   inside the `.glb` file and readable in Godot via `node.get_meta("linkforge")`.
+The workflow is straightforward:
+
+1. Author your robot in Blender using LinkForge as normal.
+2. Go to **File → Export → glTF 2.0**.
+3. Under the **Data** section, enable **Custom Properties**.
+4. The exported `.glb` file will contain all LinkForge robot data (mass, joints, limits,
+   sensors…) embedded as JSON metadata alongside the 3D geometry.
+5. In your target tool, read the metadata using its standard glTF custom properties API.
 
 ```{important}
 These property keys are **stable**. They will not be renamed without a major version bump and

--- a/docs/source/reference/blender_properties_schema.md
+++ b/docs/source/reference/blender_properties_schema.md
@@ -6,9 +6,9 @@ This page is the authoritative reference for every property key, its type, and i
 ## Using LinkForge Data in External Tools
 
 Because all LinkForge data is stored as standard Blender custom properties, any tool that
-supports **glTF 2.0 Custom Properties** can read it — game engines (Godot, Unity, Unreal),
-web renderers (Three.js, Babylon.js), or any custom C++/Python pipeline — **without needing
-a URDF parser**.
+supports **glTF 2.0 Custom Properties** can read it without needing a URDF parser. This
+includes game engines (Godot, Unity, Unreal), web renderers (Three.js, Babylon.js), and
+any custom C++ or Python pipeline.
 
 The workflow is straightforward:
 

--- a/docs/source/reference/blender_properties_schema.md
+++ b/docs/source/reference/blender_properties_schema.md
@@ -1,0 +1,206 @@
+# Blender Properties Schema
+
+LinkForge stores all robot data as structured Blender custom properties on scene objects.
+This page documents the full schema for all property groups, their keys, types, and default
+values.
+
+This schema is the stable foundation of LinkForge. External tools (e.g. Godot, Unity, custom
+pipelines) can access this data by enabling **Custom Properties** in Blender's glTF exporter
+(`File → Export → glTF 2.0 → Data → Custom Properties`), which embeds all properties as
+JSON metadata inside the `.glb` file.
+
+```{important}
+These property keys are considered **stable**. They will not be renamed without a major
+version bump and a clear migration note in the [CHANGELOG](../CHANGELOG.md).
+```
+
+---
+
+## Property Group Keys
+
+Each property group is attached to a Blender `Object` under a fixed attribute name:
+
+| Attribute on `bpy.types.Object` | Applies To | Purpose |
+|---|---|---|
+| `linkforge` | Link Empty | Robot link physics and identification |
+| `linkforge_joint` | Joint Empty | Joint kinematics and limits |
+| `linkforge_sensor` | Sensor Empty | Sensor configuration |
+| `linkforge_transmission` | Joint Empty | ROS 2 transmission data |
+| `linkforge_control` | Robot root | ROS 2 Control hardware interface |
+
+---
+
+## `linkforge` — Link Properties
+
+Stored on **Link Empty** objects (parent of visual/collision meshes).
+
+### Identification
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `is_robot_link` | `bool` | `false` | Marks this object as a robot link |
+| `source_name_stored` | `str` | `""` | Persistent robot-model name (immune to Blender `.001` suffixing) |
+
+### Physics
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `mass` | `float` | `1.0` | Mass in kilograms |
+| `use_auto_inertia` | `bool` | `true` | Auto-calculate inertia from geometry |
+| `inertia_ixx` | `float` | `1.0` | Moment of inertia around X axis (kg·m²) |
+| `inertia_iyy` | `float` | `1.0` | Moment of inertia around Y axis (kg·m²) |
+| `inertia_izz` | `float` | `1.0` | Moment of inertia around Z axis (kg·m²) |
+| `inertia_ixy` | `float` | `0.0` | Product of inertia XY (kg·m²) |
+| `inertia_ixz` | `float` | `0.0` | Product of inertia XZ (kg·m²) |
+| `inertia_iyz` | `float` | `0.0` | Product of inertia YZ (kg·m²) |
+| `inertia_origin_xyz` | `float[3]` | `[0,0,0]` | Center of mass offset (meters) |
+| `inertia_origin_rpy` | `float[3]` | `[0,0,0]` | Center of mass rotation (radians, XYZ) |
+
+### Collision
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `collision_type` | `str` (enum) | `"auto"` | Collision shape: `"auto"`, `"box"`, `"sphere"`, `"cylinder"`, `"mesh"` |
+| `collision_quality` | `float` | `50.0` | Mesh simplification percentage (1–100%) |
+
+### Material
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `use_material` | `bool` | `false` | Export Blender material color to URDF |
+
+### Advanced Simulation (Gazebo)
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `use_simulation_props` | `bool` | `false` | Include Gazebo-specific simulation properties |
+| `self_collide` | `bool` | `false` | Allow self-collision with other links |
+| `gravity` | `bool` | `true` | Affected by gravity |
+| `mu` | `float` | `1.0` | Static (Coulomb) friction coefficient |
+| `mu2` | `float` | `1.0` | Dynamic friction coefficient |
+| `kp` | `float` | `1e12` | Contact stiffness (N/m) |
+| `kd` | `float` | `1.0` | Contact damping (N·s/m) |
+
+---
+
+## `linkforge_joint` — Joint Properties
+
+Stored on **Joint Empty** objects (colored ARROWS empties).
+
+### Identification
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `is_robot_joint` | `bool` | `false` | Marks this object as a robot joint |
+| `source_name_stored` | `str` | `""` | Persistent robot-model name |
+
+### Kinematics
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `joint_type` | `str` (enum) | `"revolute"` | `"revolute"`, `"continuous"`, `"prismatic"`, `"fixed"`, `"floating"`, `"planar"` |
+| `parent_link` | `Object ref` | `None` | The parent link object |
+| `child_link` | `Object ref` | `None` | The child link object |
+| `axis` | `str` (enum) | `"Z"` | Joint motion axis: `"X"`, `"Y"`, `"Z"`, `"CUSTOM"` |
+| `custom_axis_x` | `float` | `0.0` | Custom axis X component (normalized) |
+| `custom_axis_y` | `float` | `0.0` | Custom axis Y component (normalized) |
+| `custom_axis_z` | `float` | `1.0` | Custom axis Z component (normalized) |
+
+### Limits
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `use_limits` | `bool` | `false` | Enable position limits |
+| `limit_lower` | `float` | `-π` | Lower position limit (rad or m) |
+| `limit_upper` | `float` | `+π` | Upper position limit (rad or m) |
+| `limit_effort` | `float` | `10.0` | Maximum force/torque (N or N·m) |
+| `limit_velocity` | `float` | `1.0` | Maximum velocity (rad/s or m/s) |
+
+### Dynamics
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `use_dynamics` | `bool` | `false` | Enable friction/damping |
+| `dynamics_damping` | `float` | `0.0` | Resistance to motion |
+| `dynamics_friction` | `float` | `0.0` | Static friction |
+
+### Mimic
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `use_mimic` | `bool` | `false` | Copy another joint's movement |
+| `mimic_joint` | `Object ref` | `None` | Joint to copy from |
+| `mimic_multiplier` | `float` | `1.0` | Movement scale factor |
+| `mimic_offset` | `float` | `0.0` | Position offset after multiplier |
+
+---
+
+## `linkforge_sensor` — Sensor Properties
+
+Stored on **Sensor Empty** objects.
+
+### Identification
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `is_robot_sensor` | `bool` | `false` | Marks this object as a robot sensor |
+| `source_name_stored` | `str` | `""` | Persistent robot-model name |
+| `sensor_type` | `str` (enum) | `"camera"` | `"camera"`, `"depth_camera"`, `"lidar"`, `"gpu_lidar"`, `"imu"`, `"gps"`, `"contact"`, `"force_torque"` |
+| `attached_link` | `Object ref` | `None` | The link this sensor is mounted on |
+
+### Common
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `update_rate` | `float` | `30.0` | Sensor update frequency (Hz) |
+| `always_on` | `bool` | `true` | Keep sensor active at all times |
+| `visualize` | `bool` | `false` | Visualize sensor in simulator |
+| `topic_name` | `str` | `""` | ROS topic name for sensor data |
+
+### Camera / Depth Camera
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `camera_horizontal_fov` | `float` | `1.047` | Horizontal field of view (radians) |
+| `camera_width` | `int` | `640` | Image width (pixels) |
+| `camera_height` | `int` | `480` | Image height (pixels) |
+| `camera_near_clip` | `float` | `0.1` | Near clipping distance (m) |
+| `camera_far_clip` | `float` | `100.0` | Far clipping distance (m) |
+| `camera_format` | `str` (enum) | `"R8G8B8"` | Pixel format |
+
+### LIDAR / GPU LIDAR
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `lidar_horizontal_samples` | `int` | `360` | Horizontal scan samples |
+| `lidar_horizontal_min_angle` | `float` | `-π` | Min horizontal angle (radians) |
+| `lidar_horizontal_max_angle` | `float` | `+π` | Max horizontal angle (radians) |
+| `lidar_vertical_samples` | `int` | `1` | Vertical scan samples (1 = 2D) |
+| `lidar_vertical_min_angle` | `float` | `0.0` | Min vertical angle (radians) |
+| `lidar_vertical_max_angle` | `float` | `0.0` | Max vertical angle (radians) |
+| `lidar_range_min` | `float` | `0.08` | Minimum range (m) |
+| `lidar_range_max` | `float` | `10.0` | Maximum range (m) |
+| `lidar_range_resolution` | `float` | `0.01` | Range resolution (m) |
+
+### Noise
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `use_noise` | `bool` | `false` | Add noise model to sensor output |
+| `noise_type` | `str` (enum) | `"gaussian"` | `"gaussian"` or `"gaussian_quantized"` |
+| `noise_mean` | `float` | `0.0` | Noise mean |
+| `noise_stddev` | `float` | `0.0` | Noise standard deviation |
+
+---
+
+## Raw ID Properties (Mesh children)
+
+These are plain Blender ID properties (not PropertyGroups) set directly on visual and
+collision mesh objects using `object["key"] = value`:
+
+| Key | Type | Description |
+|---|---|---|
+| `collision_geometry_type` | `str` | Shape type: `"box"`, `"sphere"`, `"cylinder"`, `"mesh"` |
+| `imported_from_source` | `bool` | `true` if object was created by importing a URDF |
+| `source_geometry_type` | `str` | Original geometry type from imported URDF |
+| `source_name` | `str` | Original name from imported URDF |

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -31,7 +31,7 @@ A quick reference for robotics and Blender terminology used in the project.
 :link: blender_properties_schema
 :link-type: doc
 
-Full reference of all LinkForge property keys, types, and defaults. Useful for external tools (Godot, Unity, custom pipelines) consuming LinkForge data via glTF Custom Properties.
+Full reference of all LinkForge property keys, types, and defaults. Useful for any external tool consuming LinkForge data via glTF Custom Properties.
 :::
 
 :::{grid-item-card} 🧪 Testing

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -27,6 +27,13 @@ Technical mapping of joints, links, and sensor hierarchies.
 A quick reference for robotics and Blender terminology used in the project.
 :::
 
+:::{grid-item-card} 🔌 Blender Properties Schema
+:link: blender_properties_schema
+:link-type: doc
+
+Full reference of all LinkForge property keys, types, and defaults. Useful for external tools (Godot, Unity, custom pipelines) consuming LinkForge data via glTF Custom Properties.
+:::
+
 :::{grid-item-card} 🧪 Testing
 :link: testing/automated_testing
 :link-type: doc
@@ -43,6 +50,7 @@ Automated test protocols, integration subdirectories, and Manual QA requirements
 api/index
 robot_structure
 glossary
+blender_properties_schema
 testing/automated_testing
 testing/manual_qa
 ```

--- a/platforms/blender/src/linkforge/blender/adapters/blender_to_core.py
+++ b/platforms/blender/src/linkforge/blender/adapters/blender_to_core.py
@@ -240,34 +240,25 @@ def get_object_geometry(
         # Apply offset to get the true center of the geometry
         geom_world_matrix = obj.matrix_world @ Matrix.Translation(local_center)
 
-    if actual_geometry_type == GEOM_BOX:
         dimensions = getattr(obj, "dimensions", None)
         if dimensions is None:
             return None, Matrix.Identity(4)
 
-        # Robustness Check: Skip zero-size objects (e.g. empties from failed imports)
         if dimensions.length < GEOM_EPSILON:
             logger.warning(f"Skipping geometry for '{obj.name}': Dimensions are zero.")
             return None, Matrix.Identity(4)
 
-        return Box(size=Vector3(dimensions.x, dimensions.y, dimensions.z)), geom_world_matrix
+        if actual_geometry_type == GEOM_BOX:
+            return Box(size=Vector3(dimensions.x, dimensions.y, dimensions.z)), geom_world_matrix
 
-    elif actual_geometry_type == GEOM_CYLINDER:
-        dimensions = getattr(obj, "dimensions", None)
-        if dimensions is None:
-            return None, Matrix.Identity(4)
+        elif actual_geometry_type == GEOM_CYLINDER:
+            radius = max(dimensions.x, dimensions.y) / 2.0
+            length = dimensions.z
+            return Cylinder(radius=radius, length=length), geom_world_matrix
 
-        radius = max(dimensions.x, dimensions.y) / 2.0
-        length = dimensions.z
-        return Cylinder(radius=radius, length=length), geom_world_matrix
-
-    elif actual_geometry_type == GEOM_SPHERE:
-        dimensions = getattr(obj, "dimensions", None)
-        if dimensions is None:
-            return None, Matrix.Identity(4)
-
-        radius = max(dimensions) / 2.0
-        return Sphere(radius=radius), geom_world_matrix
+        elif actual_geometry_type == GEOM_SPHERE:
+            radius = max(dimensions) / 2.0
+            return Sphere(radius=radius), geom_world_matrix
 
     return None, Matrix.Identity(4)
 

--- a/platforms/blender/src/linkforge/blender/adapters/blender_to_core.py
+++ b/platforms/blender/src/linkforge/blender/adapters/blender_to_core.py
@@ -62,6 +62,7 @@ from ..utils.property_helpers import (
     get_sensor_props,
     get_transmission_props,
 )
+from ..utils.transform_utils import get_local_bounding_box_center
 from .context import IBlenderContext
 from .translator import (
     Ros2ControlTranslator,
@@ -233,7 +234,11 @@ def get_object_geometry(
 
         actual_geometry_type = GEOM_BOX
 
-    geom_world_matrix = obj.matrix_world
+    if actual_geometry_type in (GEOM_BOX, GEOM_CYLINDER, GEOM_SPHERE):
+        # Calculate local geometric center from bounding box
+        local_center = get_local_bounding_box_center(obj)
+        # Apply offset to get the true center of the geometry
+        geom_world_matrix = obj.matrix_world @ Matrix.Translation(local_center)
 
     if actual_geometry_type == GEOM_BOX:
         dimensions = getattr(obj, "dimensions", None)

--- a/platforms/blender/src/linkforge/blender/adapters/mesh_io.py
+++ b/platforms/blender/src/linkforge/blender/adapters/mesh_io.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import bpy
-from mathutils import Matrix, Vector
+from mathutils import Matrix
 
 from ..constants import (
     FORMAT_GLB,
@@ -22,6 +22,7 @@ from ..core._utils.string_utils import sanitize_name
 from ..core.constants import (
     EPSILON,
 )
+from ..utils.transform_utils import get_local_bounding_box_center
 
 logger = get_logger(__name__)
 
@@ -328,12 +329,8 @@ def export_link_mesh(
             depsgraph = bpy.context.evaluated_depsgraph_get()
         obj_eval = obj.evaluated_get(depsgraph)
 
-        # Corners are in local space
-        local_corners = [Vector(corner) for corner in obj_eval.bound_box]
-
-        min_v = Vector(tuple(min(v[i] for v in local_corners) for i in range(3)))
-        max_v = Vector(tuple(max(v[i] for v in local_corners) for i in range(3)))
-        local_center = (min_v + max_v) / 2
+        # Calculate local geometric center of the EVALUATED mesh
+        local_center = get_local_bounding_box_center(obj_eval)
 
         # Create the final mesh data (evaluated with modifiers applied)
         final_mesh_data = bpy.data.meshes.new_from_object(

--- a/platforms/blender/src/linkforge/blender/operators/joint_ops.py
+++ b/platforms/blender/src/linkforge/blender/operators/joint_ops.py
@@ -123,6 +123,11 @@ class LINKFORGE_OT_create_joint(Operator):
             # User can disable if not needed
             joint_props.use_limits = True
 
+            # Update the view layer so that joint_empty.matrix_world is correctly calculated
+            # with the newly assigned rotation before parenting logic runs.
+            if context.view_layer:
+                context.view_layer.update()
+
             # Auto-set child link to the selected link (parent must be set manually)
             joint_props.child_link = link_obj
 

--- a/platforms/blender/src/linkforge/blender/utils/transform_utils.py
+++ b/platforms/blender/src/linkforge/blender/utils/transform_utils.py
@@ -8,9 +8,10 @@ from ..core import Transform, Vector3
 from ..core._utils.math_utils import clean_float
 
 try:
-    from mathutils import Matrix
+    from mathutils import Matrix, Vector
 except ImportError:
     Matrix = None  # type: ignore[assignment,misc]
+    Vector = None  # type: ignore[assignment,misc]
 
 
 def matrix_to_transform(matrix: Any) -> Transform:
@@ -99,11 +100,7 @@ def get_local_bounding_box_center(obj: Any) -> Any:
     """
     if not hasattr(obj, "bound_box") or not obj.bound_box:
         # Fallback for objects without bounding boxes
-        from mathutils import Vector
-
         return Vector((0.0, 0.0, 0.0))
-
-    from mathutils import Vector
 
     local_corners = [Vector(corner) for corner in obj.bound_box]
     min_v = Vector(tuple(min(v[i] for v in local_corners) for i in range(3)))

--- a/platforms/blender/src/linkforge/blender/utils/transform_utils.py
+++ b/platforms/blender/src/linkforge/blender/utils/transform_utils.py
@@ -98,6 +98,9 @@ def get_local_bounding_box_center(obj: Any) -> Any:
     Returns:
         mathutils.Vector representing the local center offset.
     """
+    if Vector is None:
+        return (0.0, 0.0, 0.0)
+
     if not hasattr(obj, "bound_box") or not obj.bound_box:
         # Fallback for objects without bounding boxes
         return Vector((0.0, 0.0, 0.0))

--- a/platforms/blender/src/linkforge/blender/utils/transform_utils.py
+++ b/platforms/blender/src/linkforge/blender/utils/transform_utils.py
@@ -86,3 +86,26 @@ def clear_parent_keep_transform(child_obj: Any) -> None:
 
     # Restore world transform (since parent is now None, World == Local)
     child_obj.matrix_world = pk_mw
+
+
+def get_local_bounding_box_center(obj: Any) -> Any:
+    """Calculate the geometric center of an object's bounding box in local space.
+
+    Args:
+        obj: Blender object (must have bound_box attribute)
+
+    Returns:
+        mathutils.Vector representing the local center offset.
+    """
+    if not hasattr(obj, "bound_box") or not obj.bound_box:
+        # Fallback for objects without bounding boxes
+        from mathutils import Vector
+
+        return Vector((0.0, 0.0, 0.0))
+
+    from mathutils import Vector
+
+    local_corners = [Vector(corner) for corner in obj.bound_box]
+    min_v = Vector(tuple(min(v[i] for v in local_corners) for i in range(3)))
+    max_v = Vector(tuple(max(v[i] for v in local_corners) for i in range(3)))
+    return (min_v + max_v) / 2

--- a/tests/unit/platforms/blender/test_joints.py
+++ b/tests/unit/platforms/blender/test_joints.py
@@ -87,6 +87,36 @@ class TestJointOperations:
         assert safe_get_joint(joint).is_robot_joint
         assert safe_get_joint(joint).child_link == link
 
+    def test_create_joint_preserves_child_rotation(self, scene, blender_context) -> None:
+        """Test that creating a joint preserves the link's world rotation."""
+        from mathutils import Euler
+
+        link = create_robot_link("rotated_link", scene)
+        # Apply some initial rotation to the link
+        link.rotation_euler = Euler((0.1, 0.2, 0.3), "XYZ")
+
+        assert bpy.context.view_layer is not None
+        bpy.context.view_layer.update()
+
+        # Save original world matrix rotation
+        original_matrix_world = link.matrix_world.copy()
+        original_rot = original_matrix_world.to_euler()
+
+        bpy.context.view_layer.objects.active = link
+        link.select_set(True)
+
+        op = LINKFORGE_OT_create_joint()
+        res = op.execute(bpy.context)
+        assert res == {"FINISHED"}
+
+        bpy.context.view_layer.update()
+
+        # The global rotation of the link should remain exactly the same
+        new_rot = link.matrix_world.to_euler()
+        assert new_rot.x == pytest.approx(original_rot.x, abs=1e-4)
+        assert new_rot.y == pytest.approx(original_rot.y, abs=1e-4)
+        assert new_rot.z == pytest.approx(original_rot.z, abs=1e-4)
+
     def test_create_joint_operator_fallback(self, scene, blender_context) -> None:
         """Test create joint operator fallback when pref is missing."""
         link = create_robot_link("base", scene)

--- a/tests/unit/platforms/blender/test_transform_utils.py
+++ b/tests/unit/platforms/blender/test_transform_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from linkforge.blender.utils.transform_utils import (
     clear_parent_keep_transform,
+    get_local_bounding_box_center,
     set_parent_keep_transform,
 )
 
@@ -52,6 +53,33 @@ class TestTransformUtilities:
     def test_clear_parent_keep_transform_none_input(self) -> None:
         """Test clearing parent guard with None input."""
         clear_parent_keep_transform(None)
+
+    def test_get_local_bounding_box_center(self, scene) -> None:
+        """Test bounding box center extraction logic."""
+        # Object with no bound box (fallback)
+        obj_no_bbox = create_test_object("test_empty", None, scene)
+        center_empty = get_local_bounding_box_center(obj_no_bbox)
+        assert center_empty.x == 0.0
+        assert center_empty.y == 0.0
+        assert center_empty.z == 0.0
+
+        # Object with actual bounding box (offset)
+        # Mock bound_box: A box from (0,0,0) to (2,4,6)
+        # The center should be at (1,2,3)
+        obj_no_bbox.bound_box = [
+            (0.0, 0.0, 0.0),
+            (0.0, 4.0, 0.0),
+            (2.0, 4.0, 0.0),
+            (2.0, 0.0, 0.0),
+            (0.0, 0.0, 6.0),
+            (0.0, 4.0, 6.0),
+            (2.0, 4.0, 6.0),
+            (2.0, 0.0, 6.0),
+        ]
+        center = get_local_bounding_box_center(obj_no_bbox)
+        assert center.x == 1.0
+        assert center.y == 2.0
+        assert center.z == 3.0
 
 
 # Rotation Normalization

--- a/uv.lock
+++ b/uv.lock
@@ -451,7 +451,7 @@ wheels = [
 
 [[package]]
 name = "linkforge-blender"
-version = "1.4.2"
+version = "1.4.3"
 source = { editable = "platforms/blender" }
 dependencies = [
     { name = "linkforge-core" },
@@ -462,7 +462,7 @@ requires-dist = [{ name = "linkforge-core", editable = "core" }]
 
 [[package]]
 name = "linkforge-core"
-version = "1.4.2"
+version = "1.4.3"
 source = { editable = "core" }
 dependencies = [
     { name = "pyyaml" },
@@ -473,7 +473,7 @@ requires-dist = [{ name = "pyyaml", specifier = ">=6.0.3" }]
 
 [[package]]
 name = "linkforge-workspace"
-version = "1.4.2"
+version = "1.4.3"
 source = { virtual = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
# Pull Request

> [!IMPORTANT]
> This project uses **Conventional Commits** and **Release Please** for automated versioning.
> Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat: add lidar sensor`, `fix: core logic bug`).

## 📝 Description

This PR addresses two separate issues in the Blender integration:
1. **Fixes Joint Rotation Doubling (#276):** Explicitly updates the view layer before assigning the child link during joint creation. This forces Blender to evaluate the new joint's rotation matrix, preventing the child link from visually doubling its rotation when parented.
2. **Fixes Primitive Origin Calculation (#273):** Computes the proper bounding box center for primitives, alongside refactored and consolidated dimension checks.

## Changes
- Added `context.view_layer.update()` in `joint_ops.py` before parenting.
- Refactored primitive dimension checks and bounding box logic.
- Added tests for bounding box center logic.
- Added tests to ensure joint creation preserves child global rotation.
- Updated `uv.lock`.

Closes #273 
Closes #276 


## 🛠️ Type of change
- [x] 🐞 Bug fix (fix)
- [x] 🧪 Tests (test)

## ✅ Checklist
- [x] `just test-core` passes (Core unit + integration)
- [x] `just test-unit-blender` passes (Blender unit tests)
- [x] `just pre-commit` passes (format, lint, type checks)
- [x] I have verified the changes manually in the Blender viewport
- [x] I have updated the documentation or verified no changes are needed
