### PR TITLE
perf(blender): skip non-object datablocks in name sync depsgraph handler

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,8 +28,9 @@
 ## 🛠️ Type of change
 - [ ] 🚀 New feature (feat)
 - [ ] 🐞 Bug fix (fix)
-- [ ] 🧪 Tests (test)
+- [ ] ⚡ Performance (perf)
 - [ ] 🧹 Refactor (refactor)
+- [ ] 🧪 Tests (test)
 - [ ] 📚 Documentation (docs)
 - [ ] 🎨 Style/Linting (style)
 - [ ] ⚙️ Maintenance (chore)

--- a/platforms/blender/src/linkforge/blender/handlers/name_sync_handler.py
+++ b/platforms/blender/src/linkforge/blender/handlers/name_sync_handler.py
@@ -61,6 +61,11 @@ def on_depsgraph_update_post(_scene: typing.Any, _depsgraph: typing.Any) -> None
     for update in _depsgraph.updates:
         obj = update.id
 
+        # Fast filter: skip non-Object datablocks (e.g. Meshes, Materials, NodeTrees)
+        # to eliminate depsgraph evaluation overhead for unrelated scene changes.
+        if not getattr(obj, "type", None):
+            continue
+
         # 1. Sync Link identities
         if (lf := get_link_props(obj)) and lf.is_robot_link:
             sanitized = sanitize_name(obj.name)

--- a/tests/unit/platforms/blender/test_name_sync_handler.py
+++ b/tests/unit/platforms/blender/test_name_sync_handler.py
@@ -114,7 +114,10 @@ def test_on_depsgraph_update_post_all_branches(scene):
         def __init__(self, updates):
             self.updates = updates
 
+    non_object_datablock = object()  # Simulates Material, NodeTree, Mesh ID without .type
+
     updates = [
+        MockUpdate(non_object_datablock),
         MockUpdate(link_true),
         MockUpdate(link_false),
         MockUpdate(joint_true),


### PR DESCRIPTION
# Pull Request

> [!IMPORTANT]
> This project uses **Conventional Commits** and **Release Please** for automated versioning.
> Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat: add lidar sensor`, `fix: core logic bug`).

## 📝 Description
Optimizes the `on_depsgraph_update_post` handler in `name_sync_handler.py` by adding an early-exit filter for non-Object datablocks (e.g., Meshes, Materials, NodeTrees, Worlds). 
Because Blender triggers dependency graph updates on any datablock change in the scene, this ensures LinkForge completely avoids inspecting properties on datablocks that cannot be robot components, minimizing evaluation overhead during active modeling and rendering.

## 🛠️ Type of change
- [x] ⚡ Performance (perf)

## ✅ Checklist
- [x] `just test-core` passes (Core unit + integration)
- [x] `just test-unit-blender` passes (Blender unit tests)
- [x] `just pre-commit` passes (format, lint, type checks)
- [x] I have verified the changes manually in the Blender viewport
- [x] I have updated the documentation or verified no changes are needed
