### PR TITLE
fix(blender): validate joint link definitions and gracefully handle orphaned control joints

### DIFF
--- a/docs/source/how_to/control_dashboard.md
+++ b/docs/source/how_to/control_dashboard.md
@@ -26,6 +26,14 @@ Select a joint in the list to reveal its settings:
 Standard ROS 2 controllers (like `diff_drive_controller`) typically require **Velocity** command interfaces for wheels.
 :::
 
+### Managing and Cleaning Up Joints
+The vertical toolbar on the right side of the joint list provides tools to manage and maintain your control configuration:
+
+- **Remove (-)**: Unregisters the currently selected joint from the control list without deleting the joint object from the Blender scene.
+- **Reorder (▲ / ▼)**: Moves the selected joint up or down in the interface list.
+- **Prune Missing Joints (🗑️)**: If a physical joint object is deleted from the 3D Viewport or Outliner, the list item flags it with an `[ERROR] <name> (Missing)` badge. A red **Trash** icon automatically appears in the toolbar. Clicking it removes all orphaned joints while preserving your remaining configured joints and PID parameters.
+- **Purge Control Data (🔄)**: Clears all `ros2_control` joints and parameters at once when you want to reset the control system and start over from scratch.
+
 ## 3. Global Hardware Settings
 In the **Hardware System** section, you can configure:
 - **Name**: The name of the `ros2_control` system (default: `GazeboSimSystem`).

--- a/platforms/blender/src/linkforge/blender/adapters/blender_to_core.py
+++ b/platforms/blender/src/linkforge/blender/adapters/blender_to_core.py
@@ -560,7 +560,7 @@ class SceneToRobotTranslator:
         self.builder = RobotBuilder(self.robot_name)
         self.validation_result = ValidationResult(robot_name=self.robot_name)
 
-    def translate(self) -> tuple[Robot, ValidationResult]:
+    def translate(self, raise_on_error: bool = True) -> tuple[Robot, ValidationResult]:
         """Perform the translation and return the built Robot model."""
         # 1. Categorize scene objects
         link_objects, joint_objects, sensor_objects, transmission_objects, joints_map, root = (
@@ -606,7 +606,7 @@ class SceneToRobotTranslator:
             )
             robot = Robot(name=self.robot_name)
 
-        if self.validation_result.errors:
+        if raise_on_error and self.validation_result.errors:
             first_err = self.validation_result.errors[0]
             raise RobotValidationError(
                 ValidationErrorCode.INVALID_VALUE,
@@ -796,6 +796,7 @@ def scene_to_robot(
     context: IBlenderContext | bpy.types.Context,
     meshes_dir: Path | None = None,
     dry_run: bool = False,
+    raise_on_error: bool = True,
 ) -> tuple[Robot, ValidationResult]:
     """Convert entire Blender scene to Core Robot using the Translator orchestrator."""
     from .context import BlenderContext
@@ -807,4 +808,4 @@ def scene_to_robot(
         context = BlenderContext(bpy)
 
     translator = SceneToRobotTranslator(context, meshes_dir, dry_run)
-    return translator.translate()
+    return translator.translate(raise_on_error=raise_on_error)

--- a/platforms/blender/src/linkforge/blender/adapters/blender_to_core.py
+++ b/platforms/blender/src/linkforge/blender/adapters/blender_to_core.py
@@ -441,7 +441,10 @@ def _categorize_scene_objects(
                 else (child_obj.name if child_obj else "")
             )
 
-            if parent_name and child_name:
+            parent_is_link = bool(parent_props and getattr(parent_props, "is_robot_link", False))
+            child_is_link = bool(child_props and getattr(child_props, "is_robot_link", False))
+
+            if parent_name and child_name and parent_is_link and child_is_link:
                 joints_map[child_name] = (parent_name, obj)
 
         # Check for Sensor
@@ -567,10 +570,13 @@ class SceneToRobotTranslator:
             _categorize_scene_objects(self.context.scene)
         )
 
-        # 2. Calculate coordinate frames (needed for joint relative origins)
+        # 2. Validate joint definitions (parent/child references, self-loops, duplicates)
+        self._validate_joint_definitions(joint_objects)
+
+        # 3. Calculate coordinate frames (needed for joint relative origins)
         link_frames = _calculate_link_frames(link_objects, joints_map, root)
 
-        # 3. Translate Materials globally (Centralized management)
+        # 4. Translate Materials globally (Centralized management)
         self._translate_global_materials(link_objects)
 
         # 4. Build Kinematic Tree recursively (The "Composer" way)
@@ -614,6 +620,96 @@ class SceneToRobotTranslator:
             )
 
         return robot, self.validation_result
+
+    def _validate_joint_definitions(self, joint_objects: list[Any]) -> None:
+        """Validate that all robot joints in the scene have valid parent and child links."""
+        seen_children: dict[str, str] = {}
+
+        for joint_obj in joint_objects:
+            props = get_joint_props(joint_obj)
+            if not props or not getattr(props, "is_robot_joint", False):
+                continue
+
+            joint_name = props.joint_name if props.joint_name else joint_obj.name
+            parent_obj = props.parent_link
+            child_obj = props.child_link
+
+            # Validate parent link reference
+            if not parent_obj:
+                self.validation_result.add_error(
+                    title="Missing Parent Link",
+                    message=f"Joint '{joint_name}' has no parent link assigned.",
+                    code=ValidationErrorCode.NOT_FOUND,
+                    affected_objects=[joint_name],
+                    suggestion=f"Assign a parent link to joint '{joint_name}' in the Joint panel.",
+                )
+            else:
+                parent_props = get_link_props(parent_obj)
+                parent_is_link = bool(
+                    parent_props and getattr(parent_props, "is_robot_link", False)
+                )
+                if not parent_is_link:
+                    self.validation_result.add_error(
+                        title="Invalid Parent Link",
+                        message=(
+                            f"Joint '{joint_name}' references parent object '{parent_obj.name}', "
+                            "which is not configured as a robot link."
+                        ),
+                        code=ValidationErrorCode.INVALID_VALUE,
+                        affected_objects=[joint_name, parent_obj.name],
+                        suggestion=f"Configure '{parent_obj.name}' as a robot link or select a valid parent link.",
+                    )
+
+            # Validate child link reference
+            if not child_obj:
+                self.validation_result.add_error(
+                    title="Missing Child Link",
+                    message=f"Joint '{joint_name}' has no child link assigned.",
+                    code=ValidationErrorCode.NOT_FOUND,
+                    affected_objects=[joint_name],
+                    suggestion=f"Assign a child link to joint '{joint_name}' in the Joint panel.",
+                )
+            else:
+                child_props = get_link_props(child_obj)
+                child_is_link = bool(child_props and getattr(child_props, "is_robot_link", False))
+                if not child_is_link:
+                    self.validation_result.add_error(
+                        title="Invalid Child Link",
+                        message=(
+                            f"Joint '{joint_name}' references child object '{child_obj.name}', "
+                            "which is not configured as a robot link."
+                        ),
+                        code=ValidationErrorCode.INVALID_VALUE,
+                        affected_objects=[joint_name, child_obj.name],
+                        suggestion=f"Configure '{child_obj.name}' as a robot link or select a valid child link.",
+                    )
+
+            # Validate self-referencing connection
+            if parent_obj and child_obj and parent_obj == child_obj:
+                self.validation_result.add_error(
+                    title="Self-Referencing Joint",
+                    message=f"Joint '{joint_name}' connects link '{parent_obj.name}' to itself.",
+                    code=ValidationErrorCode.HAS_CYCLE,
+                    affected_objects=[joint_name, parent_obj.name],
+                    suggestion=f"Select different links for parent and child on joint '{joint_name}'.",
+                )
+
+            # Validate duplicate child link assignment
+            if child_obj:
+                child_key = child_obj.name
+                if child_key in seen_children:
+                    self.validation_result.add_error(
+                        title="Duplicate Child Link Assignment",
+                        message=(
+                            f"Child link '{child_key}' is assigned to multiple joints: "
+                            f"'{seen_children[child_key]}' and '{joint_name}'."
+                        ),
+                        code=ValidationErrorCode.INVALID_VALUE,
+                        affected_objects=[joint_name, seen_children[child_key], child_key],
+                        suggestion="Ensure each link is the child of at most one joint.",
+                    )
+                else:
+                    seen_children[child_key] = joint_name
 
     def _translate_global_materials(self, link_objects: dict[str, Any]) -> None:
         """Collect and register all unique materials used in the robot."""

--- a/platforms/blender/src/linkforge/blender/adapters/core_to_blender.py
+++ b/platforms/blender/src/linkforge/blender/adapters/core_to_blender.py
@@ -1056,6 +1056,20 @@ def import_robot_to_scene(
     all_joints_list = list(robot.joints)
     resolve_mimic_joints(all_joints_list, joint_objects)
 
+    # Bind ros2_control joint pointers to scene objects
+    scene = getattr(context, "scene", None)
+    if scene and hasattr(scene, PROP_ROBOT):
+        lp = getattr(scene, PROP_ROBOT)
+        control_joints = getattr(lp, "ros2_control_joints", None)
+        if control_joints:
+            try:
+                for item in control_joints:
+                    if hasattr(item, "name") and item.name in joint_objects:
+                        with contextlib.suppress(Exception):
+                            item.joint_obj = joint_objects[item.name]
+            except TypeError:
+                pass
+
     sensors_created = 0
     if hasattr(robot, "sensors") and robot.sensors:
         for sensor in robot.sensors:

--- a/platforms/blender/src/linkforge/blender/adapters/translator.py
+++ b/platforms/blender/src/linkforge/blender/adapters/translator.py
@@ -7,6 +7,7 @@ to LinkForge core models using the Composer API.
 from __future__ import annotations
 
 import logging
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
@@ -604,7 +605,22 @@ class Ros2ControlTranslator(ITranslator):
         try:
             control = self._blender_ros2_control_to_core(obj)
             if control:
-                builder.robot.add_ros2_control(control)
+                valid_joints: list[Ros2ControlJoint] = []
+                for ctrl_joint in control.joints:
+                    if builder.robot.has_joint(ctrl_joint.name):
+                        valid_joints.append(ctrl_joint)
+                    elif validation_result:
+                        validation_result.add_error(
+                            title="ROS2 Control Missing Joint",
+                            message=(
+                                f"Controlled joint '{ctrl_joint.name}' does not exist in the robot hierarchy."
+                            ),
+                            code=ValidationErrorCode.NOT_FOUND,
+                            affected_objects=[ctrl_joint.name],
+                        )
+                if valid_joints:
+                    updated_control = replace(control, joints=tuple(valid_joints))
+                    builder.robot.add_ros2_control(updated_control)
         except Exception as e:
             if validation_result:
                 validation_result.add_error(

--- a/platforms/blender/src/linkforge/blender/operators/control_ops.py
+++ b/platforms/blender/src/linkforge/blender/operators/control_ops.py
@@ -12,6 +12,7 @@ from bpy.props import IntProperty, StringProperty
 from bpy.types import Context, Operator
 
 from ..utils.decorators import OperatorReturn, safe_execute
+from ..utils.joint_utils import is_control_joint_missing
 from ..utils.property_helpers import get_joint_props, get_robot_props
 
 
@@ -346,6 +347,55 @@ class LINKFORGE_OT_purge_ros2_control_data(Operator):
         return {"FINISHED"}
 
 
+class LINKFORGE_OT_prune_ros2_control_joints(Operator):
+    """Remove joints from ros2_control that no longer exist in the scene."""
+
+    bl_idname = "linkforge.prune_ros2_control_joints"
+    bl_label = "Prune Missing Joints"
+    bl_description = "Remove joints from the control system that no longer exist in the scene"
+    bl_options = {"REGISTER", "UNDO"}
+
+    @classmethod
+    def poll(cls, context: Context) -> bool:
+        """Check if operator can run."""
+        if not (context.scene and (props := get_robot_props(context.scene))):
+            return False
+        return any(
+            is_control_joint_missing(item, context.scene) for item in props.ros2_control_joints
+        )
+
+    @safe_execute
+    def execute(self, context: Context) -> OperatorReturn:
+        """Execute the pruning of orphaned joints."""
+        scene = context.scene
+        if not scene or not (props := get_robot_props(scene)):
+            return {"CANCELLED"}
+
+        indices_to_remove = [
+            i
+            for i, item in enumerate(props.ros2_control_joints)
+            if is_control_joint_missing(item, scene)
+        ]
+
+        for idx in reversed(indices_to_remove):
+            props.ros2_control_joints.remove(idx)
+
+        # Clamp active joint index
+        total_joints = len(props.ros2_control_joints)
+        if total_joints == 0:
+            props.ros2_control_active_joint_index = 0
+        elif props.ros2_control_active_joint_index >= total_joints:
+            props.ros2_control_active_joint_index = total_joints - 1
+
+        pruned_count = len(indices_to_remove)
+        if pruned_count > 0:
+            self.report({"INFO"}, f"Pruned {pruned_count} missing joint(s) from ROS 2 Control")
+        else:
+            self.report({"INFO"}, "No missing joints found")
+
+        return {"FINISHED"}
+
+
 # Registration
 classes = [
     LINKFORGE_OT_add_ros2_control_joint,
@@ -354,6 +404,7 @@ classes = [
     LINKFORGE_OT_add_ros2_control_parameter,
     LINKFORGE_OT_remove_ros2_control_parameter,
     LINKFORGE_OT_purge_ros2_control_data,
+    LINKFORGE_OT_prune_ros2_control_joints,
 ]
 
 

--- a/platforms/blender/src/linkforge/blender/operators/export_ops.py
+++ b/platforms/blender/src/linkforge/blender/operators/export_ops.py
@@ -23,6 +23,7 @@ from ..constants import (
 from ..core import (
     LinkForgeError,
     RobotGeneratorError,
+    RobotValidationError,
     RobotValidator,
     URDFGenerator,
     XACROGenerator,
@@ -215,7 +216,17 @@ class LINKFORGE_OT_validate_robot(Operator):
 
         lf_context = BlenderContext(bpy_instance=bpy)
         try:
-            robot, conversion_result = scene_to_robot(lf_context)
+            robot, conversion_result = scene_to_robot(lf_context, raise_on_error=False)
+        except RobotValidationError as e:
+            validation_props.has_results = True
+            validation_props.is_valid = False
+            validation_props.error_count = 1
+            error_prop = validation_props.errors.add()
+            error_prop.title = "Validation Error"
+            error_prop.message = str(e)
+            error_prop.error_code = str(e.code.name)
+            self.report({"WARNING"}, f"Validation failed: {e}")
+            return {"CANCELLED"}
         except Exception as e:
             # Catch unexpected fatal build errors
             validation_props.has_results = True

--- a/platforms/blender/src/linkforge/blender/panels/control_panel.py
+++ b/platforms/blender/src/linkforge/blender/panels/control_panel.py
@@ -7,6 +7,7 @@ import typing
 
 import bpy
 
+from ..utils.joint_utils import is_control_joint_missing
 from ..utils.property_helpers import get_joint_props, get_robot_props
 from ..utils.scene_utils import build_tree_from_stats, get_robot_statistics
 
@@ -50,10 +51,16 @@ class LINKFORGE_UL_ros2_control_joints(bpy.types.UIList):
 
             # Use the joint's custom name if it exists, otherwise fall back to the object name
             display_name = item.name
-            if item.joint_obj and (jp := get_joint_props(item.joint_obj)):
-                display_name = jp.joint_name
+            scene = _context.scene if _context else None
+            is_missing = is_control_joint_missing(item, scene)
 
-            row.label(text=display_name, icon="EMPTY_AXIS")
+            if not is_missing and item.joint_obj and (jp := get_joint_props(item.joint_obj)):
+                display_name = jp.joint_name or display_name
+
+            if is_missing:
+                row.label(text=f"{display_name} (Missing)", icon="ERROR")
+            else:
+                row.label(text=display_name, icon="EMPTY_AXIS")
 
             # Indicators for enabled interfaces
             interfaces = []
@@ -239,6 +246,10 @@ class LINKFORGE_PT_control(bpy.types.Panel):
             "linkforge.move_ros2_control_joint", icon="TRIA_DOWN", text=""
         ).direction = "DOWN"
         col.separator()
+        if any(is_control_joint_missing(j, context.scene) for j in props.ros2_control_joints):
+            sub = col.column(align=True)
+            sub.alert = True
+            sub.operator("linkforge.prune_ros2_control_joints", icon="TRASH", text="")
         col.operator("linkforge.purge_ros2_control_data", icon="FILE_REFRESH", text="")
 
         # Settings for the selected joint

--- a/platforms/blender/src/linkforge/blender/utils/joint_utils.py
+++ b/platforms/blender/src/linkforge/blender/utils/joint_utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import contextlib
+
 import bpy
 
 from ..core import Joint
@@ -26,3 +28,41 @@ def resolve_mimic_joints(joints: list[Joint], joint_objects: dict[str, bpy.types
                     jp.use_mimic = True
                 jp.mimic_multiplier = joint.mimic.multiplier
                 jp.mimic_offset = joint.mimic.offset
+
+
+def is_control_joint_missing(item: bpy.types.PropertyGroup, scene: bpy.types.Scene | None) -> bool:
+    """Check if the physical joint object for a ros2_control joint is missing from the scene.
+
+    Args:
+        item: Ros2ControlJointProperty instance
+        scene: Active Blender scene
+
+    Returns:
+        bool: True if the joint object no longer exists in the active scene.
+    """
+    if not scene:
+        return True
+
+    joint_obj = getattr(item, "joint_obj", None)
+    if joint_obj is not None:
+        try:
+            if scene.objects.get(joint_obj.name) == joint_obj:
+                jp = get_joint_props(joint_obj)
+                return not (jp and jp.is_robot_joint)
+        except (ReferenceError, AttributeError):
+            return True
+        return True
+
+    # Fast O(1) name lookup in Blender C GHash (avoids iterating scene.objects)
+    item_name = getattr(item, "name", "")
+    if (
+        item_name
+        and (obj := scene.objects.get(item_name))
+        and (jp := get_joint_props(obj))
+        and jp.is_robot_joint
+    ):
+        with contextlib.suppress(Exception):
+            item.joint_obj = obj  # type: ignore[attr-defined]
+        return False
+
+    return True

--- a/platforms/blender/src/linkforge/blender/utils/property_helpers.py
+++ b/platforms/blender/src/linkforge/blender/utils/property_helpers.py
@@ -46,7 +46,7 @@ def find_property_owner(context: Context, property_group: Any, property_attr: st
     Returns:
         The object that owns this property group, or None if not found
     """
-    # Strategy 1: Check id_data (most reliable and fastest)
+    # Check id_data (most reliable and fastest)
     if (
         hasattr(property_group, "id_data")
         and property_group.id_data
@@ -56,7 +56,7 @@ def find_property_owner(context: Context, property_group: Any, property_attr: st
     ):
         return property_group.id_data
 
-    # Strategy 2: Check active object (fast fallback)
+    # Check active object (fast fallback)
     if (
         hasattr(context, "object")
         and context.object
@@ -65,13 +65,13 @@ def find_property_owner(context: Context, property_group: Any, property_attr: st
     ):
         return context.object
 
-    # Strategy 3: Check selected objects (faster than full scene search)
+    # Check selected objects (faster than full scene search)
     if hasattr(context, "selected_objects"):
         for obj in context.selected_objects:
             if hasattr(obj, property_attr) and getattr(obj, property_attr) == property_group:
                 return obj
 
-    # Strategy 4: Fall back to full scene search (slowest)
+    # Fall back to full scene search (slowest)
     if hasattr(context, "scene") and context.scene:
         for obj in context.scene.objects:
             if hasattr(obj, property_attr) and getattr(obj, property_attr) == property_group:

--- a/tests/integration/core/test_xacro_advanced_assembly.py
+++ b/tests/integration/core/test_xacro_advanced_assembly.py
@@ -97,13 +97,13 @@ def test_conditional_model_generation(tmp_path: Path, xacro_to_robot) -> None:
     xacro_file = tmp_path / "cond.xacro"
     xacro_file.write_text(xacro_content)
 
-    # Case 1: Default (gripper=true, gpu=false)
+    # Default configuration (gripper=true, gpu=false)
     robot = xacro_to_robot(xacro_file)
     assert any(link.name == "gripper" for link in robot.links)
     assert any(link.name == "cpu_sensor" for link in robot.links)
     assert not any(link.name == "gpu_sensor" for link in robot.links)
 
-    # Case 2: Custom (gripper=false, gpu=true)
+    # Custom configuration (gripper=false, gpu=true)
     robot = xacro_to_robot(xacro_file, with_gripper=False, use_gpu=True)
     assert not any(link.name == "gripper" for link in robot.links)
     assert not any(link.name == "cpu_sensor" for link in robot.links)

--- a/tests/mock_bpy_env.py
+++ b/tests/mock_bpy_env.py
@@ -1949,7 +1949,7 @@ def setup_mock_bpy():
 
         # Discover properties in __dict__ or __annotations__
         props: dict[str, dict[str, typing.Any] | MockPropertyDescriptor] = {}
-        # 1. Check annotations (for newer Python/Blender style)
+        # Check annotations (for newer Python/Blender style)
         for k, v in getattr(cls, "__annotations__", {}).items():
             if isinstance(v, str) and "bpy.props." in v:
                 # If it's a string (due to from __future__ import annotations), we might need to "eval" or mock it
@@ -1970,7 +1970,7 @@ def setup_mock_bpy():
             elif isinstance(v, MockPropertyDescriptor):
                 props[k] = v
 
-        # 2. Check __dict__ (standard assignment style)
+        # Check class dictionary (standard assignment style)
         for k, v in cls.__dict__.items():
             if isinstance(v, MockPropertyDescriptor):
                 v._discover_name(None, cls)

--- a/tests/unit/core/test_exceptions.py
+++ b/tests/unit/core/test_exceptions.py
@@ -116,7 +116,7 @@ def test_robot_security_error():
 
 
 def test_robot_math_error():
-    """Verify RobotMathError message formatting branches (Lines 178->180, 180->183)."""
+    """Verify RobotMathError message formatting with optional target and value."""
     err_none = RobotMathError(ValidationErrorCode.OUT_OF_RANGE, "divide by zero")
     assert str(err_none) == "[MATH_OUT_OF_RANGE] divide by zero"
 
@@ -153,7 +153,7 @@ def test_robot_xacro_error():
 
 
 def test_robot_xacro_recursion_error():
-    """Verify RobotXacroRecursionError formatting and branches (Line 200)."""
+    """Verify RobotXacroRecursionError formatting with and without optional reason."""
     err_no_reason = RobotXacroRecursionError(100)
     assert "Recursion depth exceeded: 100" in str(err_no_reason)
     assert "(" not in str(err_no_reason)

--- a/tests/unit/core/test_graph.py
+++ b/tests/unit/core/test_graph.py
@@ -113,11 +113,11 @@ def test_graph_diamond_dag() -> None:
     ]
     graph = KinematicGraph(links, joints)
 
-    # This hits the 'do nothing' branch in has_cycle when child is visited but not in rec_stack
+    # Child visited from multiple paths in a DAG without cycle
     assert not graph.has_cycle()
     assert graph.get_root_links() == ["A"]
 
-    # This hits the in_degree[child] != 0 branch in get_topological_link_names
+    # Topological link ordering for diamond graph
     order = graph.get_topological_link_names()
     assert order == ["A", "B", "C", "D"]
 

--- a/tests/unit/core/test_graph_topological.py
+++ b/tests/unit/core/test_graph_topological.py
@@ -60,8 +60,8 @@ def test_get_topological_joints_complex_tree() -> None:
 
 def test_get_topological_joints_with_islands() -> None:
     """Test topological sort with disconnected robots (islands)."""
-    # Robot 1: r1_base -> r1_link
-    # Robot 2: r2_base -> r2_link
+    # First disconnected chain: r1_base -> r1_link
+    # Second disconnected chain: r2_base -> r2_link
     l1 = Link(name="r1_base")
     l2 = Link(name="r1_link")
     l3 = Link(name="r2_base")

--- a/tests/unit/core/test_link_builder_advanced.py
+++ b/tests/unit/core/test_link_builder_advanced.py
@@ -177,8 +177,7 @@ class TestLinkBuilderAdvanced:
         with builder.link("link1", parent="base") as lb:
             # Inject another name into the stack to push "link1" down
             builder._parent_stack.append("some_other_link")
-            # When this context exits, "link1" is not at the top of the stack
-            # so it hits the `elif self._link_name in self._builder._parent_stack:` branch
+            # When this context exits, "link1" is removed from stack even if not at the top
 
         assert "link1" not in builder._parent_stack
         assert builder._parent_stack[-1] == "some_other_link"

--- a/tests/unit/core/test_urdf_generator.py
+++ b/tests/unit/core/test_urdf_generator.py
@@ -1562,7 +1562,7 @@ class TestURDFGenerator:
         xml = gen.generate(robot, validate=False)
         assert "libgz_ros2_control-system.so" in xml
 
-        # Case 2: Gazebo elements with NO plugins (covers 1005->1009 skip)
+        # Case 2: Gazebo elements with NO plugins
         robot.add_gazebo_element(GazeboElement(reference="base"))
         xml = gen.generate(robot, validate=False)
         assert "libgz_ros2_control-system.so" in xml
@@ -1660,10 +1660,10 @@ class TestURDFGenerator:
         robot.add_transmission(trans)
 
         gen = URDFGenerator(pretty_print=False)
-        # Call generate with unused kwargs to cover line 125
+        # Call generate with unused kwargs to ensure backwards compatibility
         xml = gen.generate(robot, validate=False, unused_opt=True)
 
-        # Direct call to _fill_gazebo_element to cover lines 796, 802, 817-818
+        # Direct call to _fill_gazebo_element with material and properties
         root_temp = ET.Element("gazebo", reference="base")
         gz_full = GazeboElement(
             reference="base", material="Gazebo/Blue", properties={"custom_prop": "custom_val"}

--- a/tests/unit/core/test_urdf_generator.py
+++ b/tests/unit/core/test_urdf_generator.py
@@ -1494,9 +1494,7 @@ class TestURDFGenerator:
         assert '<param name="p1">v1</param>' in xml
 
     def test_generate_joint_without_calibration_tags(self) -> None:
-        """Verify the generator skips calibration tags when they are empty."""
-        # This is tricky because JointCalibration fields default to None,
-        # but if we have an empty calibration object, we hit the branch.
+        # Verify empty calibration object (fields default to None) does not emit XML tags
         j = Joint(
             name="j",
             type=JointType.FIXED,
@@ -1544,7 +1542,7 @@ class TestURDFGenerator:
 
     def test_generate_ros2_control_with_empty_plugins_or_gazebo_elements(self) -> None:
         """Verify ROS2 control generation when optional plugins or Gazebo elements are missing."""
-        # Case 1: Empty gazebo_elements
+        # Empty gazebo_elements
         # Need a joint for the transmission to be valid
         j = Joint(
             name="j", type=JointType.CONTINUOUS, parent="base", child="child", axis=Vector3(1, 0, 0)
@@ -1562,7 +1560,7 @@ class TestURDFGenerator:
         xml = gen.generate(robot, validate=False)
         assert "libgz_ros2_control-system.so" in xml
 
-        # Case 2: Gazebo elements with NO plugins
+        # Gazebo elements with NO plugins
         robot.add_gazebo_element(GazeboElement(reference="base"))
         xml = gen.generate(robot, validate=False)
         assert "libgz_ros2_control-system.so" in xml

--- a/tests/unit/core/test_urdf_parser.py
+++ b/tests/unit/core/test_urdf_parser.py
@@ -1589,7 +1589,7 @@ def test_parse_with_xacro_suffix_raises_immediately(tmp_path) -> None:
     with pytest.raises(XacroDetectedError, match="XACRO file detected"):
         parser.parse(filepath)
 
-    # Call _detect_xacro_file directly to hit the 944->951 suffix branch
+    # Call _detect_xacro_file directly to test filepath suffix detection
     with pytest.raises(XacroDetectedError, match="XACRO file detected"):
         parser._detect_xacro_file(ET.Element("robot"), filepath=filepath)
 

--- a/tests/unit/core/test_validation_checks.py
+++ b/tests/unit/core/test_validation_checks.py
@@ -387,7 +387,7 @@ def test_tree_structure_check_exceptions(empty_robot, result, mocker):
     check.run(empty_robot, result)
     assert any("Kinematic graph error" in err.title for err in result.errors)
 
-    # 2b. robot.has_cycle raises RobotModelError and has_ref_errors is True
+    # Verify has_cycle error is skipped when reference errors are already present
     result.issues = []
     result.add_error(
         title="Missing parent link", message="some msg", code=ValidationErrorCode.NOT_FOUND

--- a/tests/unit/core/test_validation_edge_cases.py
+++ b/tests/unit/core/test_validation_edge_cases.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 
-import pytest
 from linkforge.core.base import RobotGenerator, RobotParser
 from linkforge.core.exceptions import RobotModelError
 from linkforge.core.models.link import Inertial, Link
@@ -96,14 +95,7 @@ def test_semantic_check_no_semantic():
     """Cover early return in SemanticCheck if no semantic model."""
     check = SemanticCheck()
     robot = Robot(name="test_robot")
-    # Force semantic to None to hit the branch if applicable,
-    # but wait, SemanticCheck checks 'if not robot.semantic:'
-    # In Robot, semantic is field(default_factory=SemanticRobotDescription)
-    # SemanticRobotDescription is always truthy unless we mock it.
-
-    mocker_semantic = pytest.importorskip("linkforge.core.models.srdf").SemanticRobotDescription
-    # Actually if it's a dataclass it might be truthy.
-
+    # Verify SemanticCheck behavior when robot semantic description is None
     robot.semantic = None  # type: ignore
     result = ValidationResult()
     check.run(robot, result)

--- a/tests/unit/core/test_xacro.py
+++ b/tests/unit/core/test_xacro.py
@@ -609,15 +609,15 @@ class TestXacroInfrastructure:
         # BoolOps
         assert _safe_eval("a == 1 and b == 2", ctx) is True
         assert _safe_eval("a == 2 or b == 2", ctx) is True
-        assert _safe_eval("False or False", ctx) is False  # Hits line 137
+        assert _safe_eval("False or False", ctx) is False
 
         # Subscript, List, Dict, Tuple
         assert _safe_eval("[a, b][1]", ctx) == 2
-        assert _safe_eval("[]", ctx) == []  # Hits line 163
+        assert _safe_eval("[]", ctx) == []
         assert _safe_eval("{'a': 1, 'b': b}['b']", ctx) == 2
         assert _safe_eval("(a, b)[0]", ctx) == 1
         assert _safe_eval("d['k']", ctx) == "v"
-        assert _safe_eval("d.k", ctx) == "v"  # Hits line 158
+        assert _safe_eval("d.k", ctx) == "v"
 
         # Unsupported operations
         with pytest.raises(TypeError, match="Unsupported AST node"):

--- a/tests/unit/core/test_xacro.py
+++ b/tests/unit/core/test_xacro.py
@@ -527,7 +527,7 @@ class TestXacroInfrastructure:
         file_c = tmp_path / "c.xacro"
         file_c.write_text('<robot xmlns:xacro="http://www.ros.org/wiki/xacro"><link/></robot>')
         parser.resolve(file_c)
-        parser.resolve(file_c)  # Hits TEMPLATE_CACHE
+        parser.resolve(file_c)  # Verify template cache reuse
 
     def test_xacro_namespaced_property(self, tmp_path) -> None:
         """Test defining a property inside a namespace."""
@@ -703,7 +703,7 @@ class TestXacroInfrastructure:
 
         resolver.properties["my_blocks"] = [ET.Element("link"), ET.Element("joint")]
         xml = '<robot xmlns:xacro="http://www.ros.org/wiki/xacro"><xacro:insert_block name="my_blocks"/></robot>'
-        # Manually call _handle_insert_block to hit the branch
+        # Test multiple elements block insertion
         elem = ET.Element("insert_block", name="my_blocks")
         res = resolver._handle_insert_block(elem)
         assert res.tag == "container"

--- a/tests/unit/core/test_xacro_generator.py
+++ b/tests/unit/core/test_xacro_generator.py
@@ -809,7 +809,7 @@ class TestXacroGenerator:
             ),
         ]
 
-        # Patch _get_macro_signature to exercise 224->229 (sig exists but not in macro_groups)
+        # Patch _get_macro_signature for when sig exists but not in macro_groups
         original_get_sig = XACROGenerator._get_macro_signature
 
         def mock_get_sig(self, link, joint):

--- a/tests/unit/core/test_xml_utils.py
+++ b/tests/unit/core/test_xml_utils.py
@@ -201,11 +201,11 @@ def test_create_xml_element_no_formatter() -> None:
 def test_parse_vector3_exception_fallback() -> None:
     """Test Vector3 parsing fallback and error handling."""
 
-    # Hit RobotMathError (re-raised)
+    # Verify RobotMathError is raised on non-numeric component
     with pytest.raises(RobotMathError):
         parse_vector3("1.0 2.0 invalid")
 
-    # Hit RobotValidationError via IndexError
+    # Verify RobotValidationError is raised when fewer than 3 components
     with pytest.raises(RobotValidationError) as exc:
         parse_vector3("1.0 2.0")
     assert "Vector3" in str(exc.value)

--- a/tests/unit/platforms/blender/test_asynchronous_builder.py
+++ b/tests/unit/platforms/blender/test_asynchronous_builder.py
@@ -40,16 +40,16 @@ def test_builder_execution_flow(scene, blender_context) -> None:
             robot, Path("/tmp/robot.urdf"), blender_context, chunk_size=1
         )
 
-        # Manually run chunks
-        # Chunk 1: setup_scene
+        # Manually run tasks step-by-step
+        # Process scene setup task
         builder.process_next_chunk()
         assert builder.completed_tasks == 1
 
-        # Chunk 2: create_collection
+        # Process collection creation task
         builder.process_next_chunk()
         assert builder.completed_tasks == 2
 
-        # Chunk 3: create_link
+        # Process link creation task
         builder.process_next_chunk()
         assert builder.completed_tasks == 3
         assert scene.linkforge.import_status != ""
@@ -280,7 +280,7 @@ def test_builder_finalize_ros2_control_joint_mapping() -> None:
             self.joint_obj = None
 
     rc_joint = DummyJointItem("joint1")
-    rc_joint2 = DummyJointItem("joint2")  # Unmatched name to cover target_obj is None loop branch
+    rc_joint2 = DummyJointItem("joint2")  # Unmatched joint name to verify missing target handling
 
     mock_context = MagicMock()
     mock_scene = MagicMock(spec=["linkforge_robot"])

--- a/tests/unit/platforms/blender/test_blender_to_core.py
+++ b/tests/unit/platforms/blender/test_blender_to_core.py
@@ -1604,7 +1604,7 @@ def test_scene_to_robot_full_integration(clean_scene, scene, blender_context) ->
     safe_get_transmission(trans).is_robot_transmission = True
     safe_get_transmission(trans).joint_name = joint
 
-    # Sensor with Gazebo Plugin (Custom mount - Hits 1071-1075)
+    # Sensor with Gazebo Plugin (Custom mount)
     lidar = create_test_object("Lidar", None, scene)
     safe_get_sensor(lidar).is_robot_sensor = True
     safe_get_sensor(lidar).sensor_type = "lidar"
@@ -1613,7 +1613,7 @@ def test_scene_to_robot_full_integration(clean_scene, scene, blender_context) ->
     safe_get_sensor(lidar).use_gazebo_plugin = True
     safe_get_sensor(lidar).plugin_filename = "liblidar.so"
 
-    # ROS2 Control (Hits 1106-1126)
+    # ROS2 Control
     scene_props = safe_get_linkforge_scene(scene)
     scene_props.use_ros2_control = True
     scene_props.ros2_control_name = "TestSystem"

--- a/tests/unit/platforms/blender/test_blender_to_core.py
+++ b/tests/unit/platforms/blender/test_blender_to_core.py
@@ -2401,8 +2401,9 @@ def test_blender_to_core_ultra_edge_cases(scene, blender_context) -> None:
     ):
         translator.translate()
 
-    # Restore root link for remaining tests
+    # Restore robot links for remaining tests
     safe_get_linkforge(root_obj).is_robot_link = True
+    safe_get_linkforge(child_obj).is_robot_link = True
 
     safe_get_linkforge(root_obj).use_material = True
 
@@ -2623,3 +2624,124 @@ class TestJointRobustness:
         assert core is not None, "Joint 'Joint' not found in robot model"
         assert core.axis is not None, "Joint axis was not fell back to default"
         assert core.axis.z == 1.0  # Default fallback
+
+
+class TestJointDefinitionValidation:
+    """Verify validation of joint parent/child connections in scene_to_robot."""
+
+    def test_joint_missing_parent_link(self, clean_scene, scene, blender_context) -> None:
+        """Verify that a joint missing its parent link produces a Missing Parent Link error."""
+        child = create_test_object("child_link", None, scene)
+        safe_get_linkforge(child).is_robot_link = True
+
+        joint = create_test_object("orphan_parent_joint", None, scene)
+        safe_get_joint(joint).is_robot_joint = True
+        safe_get_joint(joint).parent_link = None
+        safe_get_joint(joint).child_link = child
+
+        _robot, validation_result = scene_to_robot(blender_context, raise_on_error=False)
+        assert not validation_result.is_valid
+        assert any(
+            err.title == "Missing Parent Link" and "orphan_parent_joint" in err.message
+            for err in validation_result.errors
+        )
+
+    def test_joint_missing_child_link(self, clean_scene, scene, blender_context) -> None:
+        """Verify that a joint missing its child link produces a Missing Child Link error."""
+        parent = create_test_object("parent_link", None, scene)
+        safe_get_linkforge(parent).is_robot_link = True
+
+        joint = create_test_object("orphan_child_joint", None, scene)
+        safe_get_joint(joint).is_robot_joint = True
+        safe_get_joint(joint).parent_link = parent
+        safe_get_joint(joint).child_link = None
+
+        _robot, validation_result = scene_to_robot(blender_context, raise_on_error=False)
+        assert not validation_result.is_valid
+        assert any(
+            err.title == "Missing Child Link" and "orphan_child_joint" in err.message
+            for err in validation_result.errors
+        )
+
+    def test_joint_invalid_parent_link(self, clean_scene, scene, blender_context) -> None:
+        """Verify that a parent object not marked as a robot link triggers an Invalid Parent Link error."""
+        non_link = create_test_object("regular_cube", None, scene)
+        safe_get_linkforge(non_link).is_robot_link = False
+
+        child = create_test_object("valid_child", None, scene)
+        safe_get_linkforge(child).is_robot_link = True
+
+        joint = create_test_object("bad_parent_joint", None, scene)
+        safe_get_joint(joint).is_robot_joint = True
+        safe_get_joint(joint).parent_link = non_link
+        safe_get_joint(joint).child_link = child
+
+        _robot, validation_result = scene_to_robot(blender_context, raise_on_error=False)
+        assert not validation_result.is_valid
+        assert any(
+            err.title == "Invalid Parent Link" and "regular_cube" in err.message
+            for err in validation_result.errors
+        )
+
+    def test_joint_invalid_child_link(self, clean_scene, scene, blender_context) -> None:
+        """Verify that a child object not marked as a robot link triggers an Invalid Child Link error."""
+        parent = create_test_object("valid_parent", None, scene)
+        safe_get_linkforge(parent).is_robot_link = True
+
+        non_link = create_test_object("unmarked_child", None, scene)
+        safe_get_linkforge(non_link).is_robot_link = False
+
+        joint = create_test_object("bad_child_joint", None, scene)
+        safe_get_joint(joint).is_robot_joint = True
+        safe_get_joint(joint).parent_link = parent
+        safe_get_joint(joint).child_link = non_link
+
+        _robot, validation_result = scene_to_robot(blender_context, raise_on_error=False)
+        assert not validation_result.is_valid
+        assert any(
+            err.title == "Invalid Child Link" and "unmarked_child" in err.message
+            for err in validation_result.errors
+        )
+
+    def test_joint_self_referencing(self, clean_scene, scene, blender_context) -> None:
+        """Verify that a joint connecting a link to itself produces a Self-Referencing Joint error."""
+        link = create_test_object("loop_link", None, scene)
+        safe_get_linkforge(link).is_robot_link = True
+
+        joint = create_test_object("loop_joint", None, scene)
+        safe_get_joint(joint).is_robot_joint = True
+        safe_get_joint(joint).parent_link = link
+        safe_get_joint(joint).child_link = link
+
+        _robot, validation_result = scene_to_robot(blender_context, raise_on_error=False)
+        assert not validation_result.is_valid
+        assert any(
+            err.title == "Self-Referencing Joint" and "loop_joint" in err.message
+            for err in validation_result.errors
+        )
+
+    def test_joint_duplicate_child_link(self, clean_scene, scene, blender_context) -> None:
+        """Verify that assigning the same child link to multiple joints produces a duplicate error."""
+        parent1 = create_test_object("parent1", None, scene)
+        safe_get_linkforge(parent1).is_robot_link = True
+        parent2 = create_test_object("parent2", None, scene)
+        safe_get_linkforge(parent2).is_robot_link = True
+        shared_child = create_test_object("shared_child", None, scene)
+        safe_get_linkforge(shared_child).is_robot_link = True
+
+        j1 = create_test_object("joint1", None, scene)
+        safe_get_joint(j1).is_robot_joint = True
+        safe_get_joint(j1).parent_link = parent1
+        safe_get_joint(j1).child_link = shared_child
+
+        j2 = create_test_object("joint2", None, scene)
+        safe_get_joint(j2).is_robot_joint = True
+        safe_get_joint(j2).parent_link = parent2
+        safe_get_joint(j2).child_link = shared_child
+
+        _robot, validation_result = scene_to_robot(blender_context, raise_on_error=False)
+        assert not validation_result.is_valid
+        assert any(
+            err.title == "Duplicate Child Link Assignment" and "shared_child" in err.message
+            for err in validation_result.errors
+        )

--- a/tests/unit/platforms/blender/test_blender_to_core.py
+++ b/tests/unit/platforms/blender/test_blender_to_core.py
@@ -1551,7 +1551,7 @@ def test_blender_link_mesh_inertia(clean_scene, scene, blender_context) -> None:
     props = safe_get_linkforge(o)
     props.is_robot_visual = True
     props.is_robot_collision = True
-    props.geometry_type = "MESH"  # Force mesh inertia branch
+    props.geometry_type = "MESH"
 
     core = translate_link_to_model(link_obj, blender_context)
     assert core is not None
@@ -1588,7 +1588,7 @@ def test_scene_to_robot_full_integration(clean_scene, scene, blender_context) ->
 
     # Multi-visuals
     create_mesh_obj("root_link_visual_1", root, "CUBE")
-    create_mesh_obj("root_link_visual_2", root, "sphere")  # Hits Sphere branch
+    create_mesh_obj("root_link_visual_2", root, "sphere")
 
     # Joint (Needed for transmission)
     child = create_test_object("ChildLink", None, scene)
@@ -2518,7 +2518,7 @@ def test_translate_global_materials_duplicate_and_pre_registered(scene, blender_
     child2.data.materials.append(shared_mat)
 
     translator = SceneToRobotTranslator(blender_context)
-    # Pre-register SharedMat in the robot builder to trigger registered material skip branch
+    # Pre-register SharedMat in the robot builder to verify existing material reuse
     pre_registered_mat = Material(name="SharedMat", color=Color(r=0.5, g=0.5, b=0.5, a=1.0))
     translator.builder.robot.materials["SharedMat"] = pre_registered_mat
 

--- a/tests/unit/platforms/blender/test_control.py
+++ b/tests/unit/platforms/blender/test_control.py
@@ -2,17 +2,22 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+import runpy
+import types
+from unittest.mock import MagicMock, patch
 
 import bpy
+import linkforge.blender.operators.control_ops as control_ops
 from linkforge.blender.operators.control_ops import (
     LINKFORGE_OT_add_ros2_control_joint,
     LINKFORGE_OT_add_ros2_control_parameter,
     LINKFORGE_OT_move_ros2_control_joint,
+    LINKFORGE_OT_prune_ros2_control_joints,
     LINKFORGE_OT_purge_ros2_control_data,
     LINKFORGE_OT_remove_ros2_control_joint,
     LINKFORGE_OT_remove_ros2_control_parameter,
 )
+from linkforge.blender.panels.control_panel import LINKFORGE_UL_ros2_control_joints
 
 from tests.blender_test_utils import (
     create_robot_joint,
@@ -22,6 +27,7 @@ from tests.blender_test_utils import (
     safe_get_linkforge_scene,
     safe_get_sensor,
 )
+from tests.mock_bpy_env import MockCollection, MockPropertyGroup
 
 
 class TestControlOperations:
@@ -133,7 +139,6 @@ class TestControlOperations:
 
         joint = props.ros2_control_joints.add()
         joint.name = "j1"
-        from tests.mock_bpy_env import MockCollection, MockPropertyGroup
 
         joint.parameters = MockCollection(prop_type=MockPropertyGroup)
         props.ros2_control_active_joint_index = 0
@@ -162,7 +167,6 @@ class TestControlOperations:
 
         joint = props.ros2_control_joints.add()
         joint.name = "j1"
-        from tests.mock_bpy_env import MockCollection, MockPropertyGroup
 
         joint.parameters = MockCollection(prop_type=MockPropertyGroup)
         jp1 = joint.parameters.add()
@@ -186,41 +190,93 @@ class TestControlOperations:
         assert len(props.ros2_control_joints) == 0
         assert len(props.ros2_control_parameters) == 0
 
+    def test_prune_ros2_control_joints(self, scene, blender_context) -> None:
+        """Test pruning orphaned joints from ros2_control."""
+        props = safe_get_linkforge_scene(scene)
+        props.ros2_control_joints.clear()
+
+        # Valid joint
+        joint_obj = create_robot_joint("valid_j", None, None, scene)
+        joint_props = safe_get_joint(joint_obj)
+        joint_props.is_robot_joint = True
+        joint_props.joint_name = "valid_j"
+
+        item_valid = props.ros2_control_joints.add()
+        item_valid.name = "valid_j"
+        item_valid.joint_obj = joint_obj
+
+        # Orphaned joint (None pointer)
+        item_orphan = props.ros2_control_joints.add()
+        item_orphan.name = "deleted_j"
+        item_orphan.joint_obj = None
+
+        # Orphaned joint (pointer exists but unlinked from scene.objects, as when deleted in viewport)
+        unlinked_obj = create_robot_joint("unlinked_j", None, None, scene)
+        item_unlinked = props.ros2_control_joints.add()
+        item_unlinked.name = "unlinked_j"
+        item_unlinked.joint_obj = unlinked_obj
+        # Remove from scene.objects
+        scene.objects.remove(unlinked_obj)
+
+        assert len(props.ros2_control_joints) == 3
+
+        # Test UI list draw_item for missing indicator
+        ui_list = LINKFORGE_UL_ros2_control_joints()
+        ui_list.layout_type = "DEFAULT"
+        mock_layout = MagicMock()
+        mock_row = MagicMock()
+        mock_layout.row.return_value = mock_row
+
+        ui_list.draw_item(
+            bpy.context, mock_layout, props, item_orphan, None, props, "ros2_control_joints", 1
+        )
+        mock_row.label.assert_any_call(text="deleted_j (Missing)", icon="ERROR")
+
+        ui_list.draw_item(
+            bpy.context, mock_layout, props, item_unlinked, None, props, "ros2_control_joints", 2
+        )
+        mock_row.label.assert_any_call(text="unlinked_j (Missing)", icon="ERROR")
+
+        # Poll should be True while missing joints exist
+        assert LINKFORGE_OT_prune_ros2_control_joints.poll(bpy.context)
+
+        # Execute prune
+        res = LINKFORGE_OT_prune_ros2_control_joints().execute(bpy.context)
+        assert res == {"FINISHED"}
+        assert len(props.ros2_control_joints) == 1
+        assert props.ros2_control_joints[0].name == "valid_j"
+
+        # Poll should be False once all missing joints are pruned
+        assert not LINKFORGE_OT_prune_ros2_control_joints.poll(bpy.context)
+
+        # Direct execute when no missing joints remain handles gracefully
+        res2 = LINKFORGE_OT_prune_ros2_control_joints().execute(bpy.context)
+        assert res2 == {"FINISHED"}
+
     def test_control_ops_exception_handling(self, scene) -> None:
         """Verify control ops handle invalid context or registration issues."""
         op = LINKFORGE_OT_add_ros2_control_joint()
         op.joint_name = "invalid_joint"
 
-        class MockContextNoScene:
-            scene = None
+        mock_ctx_no_scene = types.SimpleNamespace(scene=None)
 
-        assert op.execute(MockContextNoScene()) == {"CANCELLED"}
+        assert op.execute(mock_ctx_no_scene) == {"CANCELLED"}
 
-        from linkforge.blender.operators.control_ops import (
-            LINKFORGE_OT_add_ros2_control_parameter,
-            LINKFORGE_OT_move_ros2_control_joint,
-            LINKFORGE_OT_purge_ros2_control_data,
-            LINKFORGE_OT_remove_ros2_control_joint,
-            LINKFORGE_OT_remove_ros2_control_parameter,
-        )
+        assert not LINKFORGE_OT_remove_ros2_control_joint.poll(mock_ctx_no_scene)
+        assert not LINKFORGE_OT_move_ros2_control_joint.poll(mock_ctx_no_scene)
+        assert not LINKFORGE_OT_add_ros2_control_parameter.poll(mock_ctx_no_scene)
+        assert not LINKFORGE_OT_remove_ros2_control_parameter.poll(mock_ctx_no_scene)
+        assert not LINKFORGE_OT_purge_ros2_control_data.poll(mock_ctx_no_scene)
+        assert not LINKFORGE_OT_prune_ros2_control_joints.poll(mock_ctx_no_scene)
 
-        assert not LINKFORGE_OT_remove_ros2_control_joint.poll(MockContextNoScene())
-        assert not LINKFORGE_OT_move_ros2_control_joint.poll(MockContextNoScene())
-        assert not LINKFORGE_OT_add_ros2_control_parameter.poll(MockContextNoScene())
-        assert not LINKFORGE_OT_remove_ros2_control_parameter.poll(MockContextNoScene())
-        assert not LINKFORGE_OT_purge_ros2_control_data.poll(MockContextNoScene())
-
-        assert LINKFORGE_OT_remove_ros2_control_joint().execute(MockContextNoScene()) == {
+        assert LINKFORGE_OT_remove_ros2_control_joint().execute(mock_ctx_no_scene) == {"CANCELLED"}
+        assert LINKFORGE_OT_move_ros2_control_joint().execute(mock_ctx_no_scene) == {"CANCELLED"}
+        assert LINKFORGE_OT_add_ros2_control_parameter().execute(mock_ctx_no_scene) == {"CANCELLED"}
+        assert LINKFORGE_OT_remove_ros2_control_parameter().execute(mock_ctx_no_scene) == {
             "CANCELLED"
         }
-        assert LINKFORGE_OT_move_ros2_control_joint().execute(MockContextNoScene()) == {"CANCELLED"}
-        assert LINKFORGE_OT_add_ros2_control_parameter().execute(MockContextNoScene()) == {
-            "CANCELLED"
-        }
-        assert LINKFORGE_OT_remove_ros2_control_parameter().execute(MockContextNoScene()) == {
-            "CANCELLED"
-        }
-        assert LINKFORGE_OT_purge_ros2_control_data().execute(MockContextNoScene()) == {"CANCELLED"}
+        assert LINKFORGE_OT_purge_ros2_control_data().execute(mock_ctx_no_scene) == {"CANCELLED"}
+        assert LINKFORGE_OT_prune_ros2_control_joints().execute(mock_ctx_no_scene) == {"CANCELLED"}
 
     def test_control_ops_parameter_boundaries(self, scene, blender_context) -> None:
         """Test parameter addition and removal boundary cases."""
@@ -240,7 +296,6 @@ class TestControlOperations:
 
         joint = props.ros2_control_joints.add()
         joint.name = "j1"
-        from tests.mock_bpy_env import MockCollection, MockPropertyGroup
 
         joint.parameters = MockCollection(prop_type=MockPropertyGroup)
         props.ros2_control_active_joint_index = 0
@@ -256,20 +311,16 @@ class TestControlOperations:
 
     def test_control_ops_registration_and_main(self, mocker) -> None:
         """Verify registration and unregistration loops including double-registration."""
-        import linkforge.blender.operators.control_ops as control_ops
-
         control_ops.unregister()
 
         mock_reg = mocker.patch(
             "bpy.utils.register_class",
-            side_effect=[ValueError("Already registered"), None, None, None, None, None, None],
+            side_effect=[ValueError("Already registered")] + [None] * 10,
         )
         mock_unreg = mocker.patch("bpy.utils.unregister_class")
         control_ops.register()
         assert mock_reg.call_count > 0
         assert mock_unreg.call_count > 0
-
-        import runpy
 
         with patch.object(control_ops, "__name__", "__main__"):
             runpy.run_module("linkforge.blender.operators.control_ops")

--- a/tests/unit/platforms/blender/test_core_to_blender.py
+++ b/tests/unit/platforms/blender/test_core_to_blender.py
@@ -1471,7 +1471,7 @@ class TestCoreToBlenderExhaustiveCoverage:
             assert import_mesh_file(blender_context, obj_path, "test_obj") is None
 
         dup_obj = create_test_object("mesh_dup", None, scene=scene)
-        # Call normalize_and_consolidate_imported_objects twice with same object to hit recursive seen check
+        # Verify duplicate object cycle handling in consolidation
         normalize_and_consolidate_imported_objects(
             blender_context, [dup_obj, dup_obj], "consolidated"
         )
@@ -1666,8 +1666,7 @@ class TestCoreToBlenderExhaustiveCoverage:
         stl_path = tmp_path / "test_import.stl"
         stl_path.touch()
 
-        # 3a. res_obj.name is ALREADY in current_col.objects
-        # 3b. res_obj.name is NOT in new_col.objects
+        # Handle object already linked in current collection
         def mock_stl_import_ok(**kwargs):
             col = bpy.data.collections.new("New_STL_Collection")
             bpy.context.scene.collection.children.link(col)
@@ -1683,7 +1682,7 @@ class TestCoreToBlenderExhaustiveCoverage:
         assert res is not None
         mocker.stopall()
 
-        # 3c. normalize_and_consolidate returns None
+        # Handle consolidation returning None
         mocker.patch(
             "linkforge.blender.adapters.core_to_blender.bpy.ops.wm.stl_import",
             return_value={"FINISHED"},
@@ -1695,7 +1694,7 @@ class TestCoreToBlenderExhaustiveCoverage:
         assert import_mesh_file(blender_context, stl_path, "none_imported") is None
         mocker.stopall()
 
-        # 3d. normalize_and_consolidate raises generic Exception
+        # Handle consolidation raising an exception
         mocker.patch(
             "linkforge.blender.adapters.core_to_blender.bpy.ops.wm.stl_import",
             return_value={"FINISHED"},
@@ -1708,7 +1707,7 @@ class TestCoreToBlenderExhaustiveCoverage:
             import_mesh_file(blender_context, stl_path, "raises_err")
         mocker.stopall()
 
-        # 3e. res_obj.name is NOT in current_col.objects
+        # Handle object not in current collection
         def mock_stl_import_not_linked(**kwargs):
             col = bpy.data.collections.new("New_STL_Collection_Not_Linked")
             bpy.context.scene.collection.children.link(col)
@@ -1835,7 +1834,7 @@ class TestCoreToBlenderExhaustiveCoverage:
         obj_j = create_joint_object(blender_context, joint_no_origin, link_objects)
         assert obj_j is not None
 
-        # 6a. Sensor values are None
+        # Verify handling of optional sensor fields when None
         sensor_none = Sensor(
             name="sensor_none",
             type=SensorType.CAMERA,
@@ -1859,7 +1858,7 @@ class TestCoreToBlenderExhaustiveCoverage:
         obj_s = create_sensor_object(blender_context, sensor_none, link_objects)
         assert obj_s is not None
 
-        # 6b. Lidar vertical_samples is None
+        # Verify handling when lidar vertical_samples is None
         lidar_none = Sensor(
             name="lidar_none",
             type=SensorType.LIDAR,
@@ -1873,7 +1872,7 @@ class TestCoreToBlenderExhaustiveCoverage:
         obj_lid = create_sensor_object(blender_context, lidar_none, link_objects)
         assert obj_lid is not None
 
-        # 6c. Setup scene for robot with ROS2 Control parameters
+        # Setup scene for robot with ROS2 Control parameters
         # and Gazebo element with plugin containing "ros2_control" and parameters
         rc_joint = Ros2ControlJoint(
             name="j1",

--- a/tests/unit/platforms/blender/test_core_to_blender.py
+++ b/tests/unit/platforms/blender/test_core_to_blender.py
@@ -1583,7 +1583,7 @@ class TestCoreToBlenderExhaustiveCoverage:
         assert _get_geometry_type_str(None) == "mesh"
 
     def test_create_material_no_default_value(self, scene, blender_context, mocker) -> None:
-        """Verify create_material_from_color when node_principled input has no default_value attribute (covers 114->118 false branch)."""
+        """Verify create_material_from_color when node_principled input has no default_value attribute."""
         mat = bpy.data.materials.new(name="no_def_val")
 
         mock_node = mocker.MagicMock()
@@ -1597,7 +1597,7 @@ class TestCoreToBlenderExhaustiveCoverage:
             assert res == mat
 
     def test_setup_scene_for_robot_uncovered_branches(self, scene, blender_context, mocker) -> None:
-        """Verify setup_scene_for_robot covered completely (996->1002 False, 1052->1054 False)."""
+        """Verify setup_scene_for_robot handles empty robot and missing properties gracefully."""
         from linkforge.blender.adapters.core_to_blender import setup_scene_for_robot
 
         mock_scene_no_prop = mocker.MagicMock(spec=[])
@@ -1666,8 +1666,8 @@ class TestCoreToBlenderExhaustiveCoverage:
         stl_path = tmp_path / "test_import.stl"
         stl_path.touch()
 
-        # 3a. res_obj.name is ALREADY in current_col.objects (covers 291 False branch)
-        # 3b. res_obj.name is NOT in new_col.objects (covers 297 False branch)
+        # 3a. res_obj.name is ALREADY in current_col.objects
+        # 3b. res_obj.name is NOT in new_col.objects
         def mock_stl_import_ok(**kwargs):
             col = bpy.data.collections.new("New_STL_Collection")
             bpy.context.scene.collection.children.link(col)
@@ -1683,7 +1683,7 @@ class TestCoreToBlenderExhaustiveCoverage:
         assert res is not None
         mocker.stopall()
 
-        # 3c. normalize_and_consolidate returns None (covers 307)
+        # 3c. normalize_and_consolidate returns None
         mocker.patch(
             "linkforge.blender.adapters.core_to_blender.bpy.ops.wm.stl_import",
             return_value={"FINISHED"},
@@ -1695,7 +1695,7 @@ class TestCoreToBlenderExhaustiveCoverage:
         assert import_mesh_file(blender_context, stl_path, "none_imported") is None
         mocker.stopall()
 
-        # 3d. normalize_and_consolidate raises generic Exception (covers 312-314)
+        # 3d. normalize_and_consolidate raises generic Exception
         mocker.patch(
             "linkforge.blender.adapters.core_to_blender.bpy.ops.wm.stl_import",
             return_value={"FINISHED"},
@@ -1708,7 +1708,7 @@ class TestCoreToBlenderExhaustiveCoverage:
             import_mesh_file(blender_context, stl_path, "raises_err")
         mocker.stopall()
 
-        # 3e. res_obj.name is NOT in current_col.objects (covers 292 statement)
+        # 3e. res_obj.name is NOT in current_col.objects
         def mock_stl_import_not_linked(**kwargs):
             col = bpy.data.collections.new("New_STL_Collection_Not_Linked")
             bpy.context.scene.collection.children.link(col)
@@ -1746,11 +1746,11 @@ class TestCoreToBlenderExhaustiveCoverage:
             pass
 
         # Link with:
-        # - Visual whose created object data has no materials (evaluates 511 False -> jumps to 448)
-        # - Collision whose created object data has no materials (evaluates 581 False -> jumps to 586)
-        # - Collision with unrecognized geometry (evaluates 599 False -> loops to 518)
-        # - Inertial without inertia (covers 606 False branch)
-        # - Inertial without origin (covers 617 False branch)
+        # - Visual whose created object data has no materials
+        # - Collision whose created object data has no materials
+        # - Collision with unrecognized geometry
+        # - Inertial without inertia
+        # - Inertial without origin
         vis = Visual(
             geometry=Box(size=Vector3(1, 1, 1)),
             material=Material(name="missing_mat", color=Color(1, 1, 1, 1)),
@@ -1807,7 +1807,7 @@ class TestCoreToBlenderExhaustiveCoverage:
         coll_sph_obj = next(c for c in obj_sph_l.children if "_collision" in c.name)
         assert getattr(coll_sph_obj, PROP_GEOM).geometry_type == GEOM_SPHERE
 
-        # Collision unrecognized type (covers 660->666 False branch)
+        # Collision unrecognized type
         mocker.patch(
             "linkforge.blender.adapters.core_to_blender._get_geometry_type_str",
             return_value="UNKNOWN",
@@ -1873,8 +1873,8 @@ class TestCoreToBlenderExhaustiveCoverage:
         obj_lid = create_sensor_object(blender_context, lidar_none, link_objects)
         assert obj_lid is not None
 
-        # 6c. Setup scene for robot with ROS2 Control parameters (covers 1013-1015 and 1032-1034)
-        # and Gazebo element with plugin containing "ros2_control" and parameters (covers 1052->1054)
+        # 6c. Setup scene for robot with ROS2 Control parameters
+        # and Gazebo element with plugin containing "ros2_control" and parameters
         rc_joint = Ros2ControlJoint(
             name="j1",
             command_interfaces=["position"],

--- a/tests/unit/platforms/blender/test_export_ops.py
+++ b/tests/unit/platforms/blender/test_export_ops.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import os
+import runpy
 from unittest.mock import MagicMock, patch
 
 import bpy
+from linkforge.blender import operators as operators_pkg
 from linkforge.blender.constants import PROP_ROBOT, PROP_VALIDATION
+from linkforge.blender.operators import export_ops
 from linkforge.blender.operators.export_ops import (
     LINKFORGE_OT_export_robot_model,
     LINKFORGE_OT_validate_robot,
@@ -18,7 +21,12 @@ from linkforge.blender.operators.export_ops import (
 from linkforge.blender.operators.export_ops import (
     unregister as export_unregister,
 )
-from linkforge.core import ValidationResult
+from linkforge.core import (
+    LinkForgeError,
+    RobotValidationError,
+    ValidationErrorCode,
+    ValidationResult,
+)
 
 from tests.blender_test_utils import safe_get_linkforge_scene
 
@@ -246,6 +254,33 @@ class TestValidateRobotOperator:
         assert mock_val_prop.error_count == 1
 
     @patch("linkforge.blender.adapters.blender_to_core.scene_to_robot")
+    def test_validate_robot_validation_error(
+        self, mock_scene_to_robot, scene, blender_context
+    ) -> None:
+        """Test validate operator handles RobotValidationError cleanly without build crash."""
+        op = LINKFORGE_OT_validate_robot()
+        op.report = MagicMock()
+
+        wm = bpy.context.window_manager
+        assert wm is not None
+        mock_val_prop = MagicMock()
+        mock_error = MagicMock()
+        mock_val_prop.errors.add.return_value = mock_error
+        setattr(wm, PROP_VALIDATION, mock_val_prop)
+
+        mock_scene_to_robot.side_effect = RobotValidationError(
+            ValidationErrorCode.NOT_FOUND, "Joint not found"
+        )
+
+        res = op.execute(bpy.context)
+        assert res == {"CANCELLED"}
+        op.report.assert_any_call({"WARNING"}, "Validation failed: [NOT_FOUND] Joint not found")
+        assert mock_val_prop.is_valid is False
+        assert mock_val_prop.error_count == 1
+        assert mock_error.title == "Validation Error"
+        assert mock_error.error_code == "NOT_FOUND"
+
+    @patch("linkforge.blender.adapters.blender_to_core.scene_to_robot")
     def test_validate_robot_success_clean(
         self, mock_scene_to_robot, scene, blender_context
     ) -> None:
@@ -328,9 +363,6 @@ class TestValidateRobotOperator:
 
     def test_registration(self, mocker) -> None:
         """Test register and unregister functions for export operator and package-level operators."""
-        import linkforge.blender.operators.export_ops as export_ops
-        from linkforge.blender import operators as operators_pkg
-
         with (
             patch("bpy.utils.register_class") as mock_reg,
             patch("bpy.utils.unregister_class") as mock_unreg,
@@ -352,8 +384,6 @@ class TestValidateRobotOperator:
         export_ops.register()
         assert mock_reg_err.call_count > 0
         assert mock_unreg_err.call_count > 0
-
-        import runpy
 
         with patch.object(export_ops, "__name__", "__main__"):
             runpy.run_module("linkforge.blender.operators.export_ops")
@@ -523,8 +553,6 @@ class TestRobotExport:
         mock_self = MagicMock()
         mock_self.filepath = "/tmp/robot.urdf"
         mock_self.report = MagicMock()
-
-        from linkforge.core import LinkForgeError
 
         mocker.patch(
             "linkforge.blender.adapters.blender_to_core.scene_to_robot",

--- a/tests/unit/platforms/blender/test_export_ops.py
+++ b/tests/unit/platforms/blender/test_export_ops.py
@@ -43,17 +43,17 @@ class TestExportOperators:
         """Test check method returns True only if scene has PROP_ROBOT."""
         op = LINKFORGE_OT_export_robot_model()
 
-        # Scenario 1: scene is None
+        # Context without scene
         mock_context = MagicMock()
         mock_context.scene = None
         assert op.check(mock_context) is False
 
-        # Scenario 2: scene is not None, but does not have PROP_ROBOT
+        # Scene missing robot properties
         mock_scene = MagicMock(spec=[])
         mock_context.scene = mock_scene
         assert op.check(mock_context) is False
 
-        # Scenario 3: scene is not None, has PROP_ROBOT
+        # Scene with robot properties present
         mock_scene = MagicMock()
         setattr(mock_scene, PROP_ROBOT, MagicMock())
         mock_context.scene = mock_scene

--- a/tests/unit/platforms/blender/test_gizmos.py
+++ b/tests/unit/platforms/blender/test_gizmos.py
@@ -49,7 +49,7 @@ class TestInertiaGizmos:
         """Test drawing lifecycle with various preference combinations."""
         gpu = inertia_gizmos.gpu
 
-        # Scenario 1: Hidden by preference
+        # Inertia gizmos hidden by preference
         with patch("linkforge.blender.visualization.inertia_gizmos.get_addon_prefs") as mock_prefs:
             prefs = MagicMock()
             prefs.show_inertia_gizmos = False
@@ -58,7 +58,7 @@ class TestInertiaGizmos:
             # Should return early
             assert inertia_gizmos.draw_inertia_gizmos() is None
 
-        # Scenario 2: Enabled preference, but no manual inertia objects
+        # Inertia gizmos enabled, but no manual inertia objects present
         with (
             patch("linkforge.blender.visualization.inertia_gizmos.get_addon_prefs") as mock_prefs,
             patch(
@@ -76,7 +76,7 @@ class TestInertiaGizmos:
 
             assert inertia_gizmos.draw_inertia_gizmos() is None
 
-        # Scenario 3: Enabled with manual inertia objects (full GPU draw branch)
+        # Enabled with manual inertia objects for GPU drawing
         link_obj = create_robot_link("manual_link", scene, with_visual=True, with_collision=False)
         lf = safe_get_linkforge(link_obj)
         lf.is_robot_link = True
@@ -235,7 +235,7 @@ class TestJointGizmos:
         """Verify joint axes overlay rendering logic branches."""
         gpu = joint_gizmos.gpu
 
-        # Scenario 1: Disabled
+        # Joint axes display disabled in preferences
         with patch("linkforge.blender.visualization.joint_gizmos.get_addon_prefs") as mock_prefs:
             prefs = MagicMock()
             prefs.show_joint_axes = False
@@ -243,7 +243,7 @@ class TestJointGizmos:
 
             assert joint_gizmos.draw_joint_axes() is None
 
-        # Scenario 2: Enabled but no joints in statistics
+        # Joint axes enabled but no joints in statistics
         with (
             patch("linkforge.blender.visualization.joint_gizmos.get_addon_prefs") as mock_prefs,
             patch(
@@ -261,7 +261,7 @@ class TestJointGizmos:
 
             assert joint_gizmos.draw_joint_axes() is None
 
-        # Scenario 3: Enabled with active joint objects (full triangles / batch rendering draw)
+        # Joint axes enabled with active joint objects for rendering
         joint_obj = bpy.data.objects.new("rendered_joint", None)
         scene.collection.objects.link(joint_obj)
         joint_obj.type = "EMPTY"
@@ -339,7 +339,7 @@ class TestJointGizmos:
 
     def test_update_viz_handle_lifecycle(self, scene) -> None:
         """Verify SpaceView3D custom drawing handler addition and removal on viz updates."""
-        # Case 1: Toggle ON
+        # Verify toggle ON registers custom drawing handler
         with (
             patch("linkforge.blender.visualization.joint_gizmos.get_addon_prefs") as mock_prefs,
             patch.object(
@@ -356,7 +356,7 @@ class TestJointGizmos:
             assert bpy.app.driver_namespace["linkforge_joint_gizmo_handler"] == "dummy_joint_handle"
             assert mock_add.called
 
-        # Case 2: Toggle OFF
+        # Verify toggle OFF unregisters drawing handler
         with (
             patch("linkforge.blender.visualization.joint_gizmos.get_addon_prefs") as mock_prefs,
             patch.object(bpy.types.SpaceView3D, "draw_handler_remove") as mock_remove,

--- a/tests/unit/platforms/blender/test_gizmos.py
+++ b/tests/unit/platforms/blender/test_gizmos.py
@@ -599,7 +599,7 @@ class TestGizmosExtra:
         inertia_gizmos._builtin_shader_name = None
 
     def test_inertia_gizmos_draw_no_prefs(self, scene) -> None:
-        """Verify draw_inertia_gizmos handles None preferences gracefully (183->190)."""
+        """Verify draw_inertia_gizmos handles None preferences gracefully."""
         with (
             patch(
                 "linkforge.blender.visualization.inertia_gizmos.get_addon_prefs", return_value=None
@@ -616,7 +616,7 @@ class TestGizmosExtra:
             inertia_gizmos.draw_inertia_gizmos()
 
     def test_inertia_gizmos_draw_empty_visible_objects(self) -> None:
-        """Verify draw_inertia_gizmos exits early when context.visible_objects is empty (196)."""
+        """Verify draw_inertia_gizmos exits early when context.visible_objects is empty."""
         mock_ctx = MagicMock()
         mock_ctx.visible_objects = []
         with (
@@ -630,7 +630,7 @@ class TestGizmosExtra:
             assert inertia_gizmos.draw_inertia_gizmos() is None
 
     def test_inertia_gizmos_draw_empty_lines_branch(self, scene) -> None:
-        """Verify draw_inertia_gizmos handles empty generated lines branch (210->207)."""
+        """Verify draw_inertia_gizmos handles empty generated lines branch."""
         link_obj = create_robot_link("dummy_link", scene)
         with (
             patch("linkforge.blender.visualization.inertia_gizmos.get_addon_prefs") as mock_prefs,
@@ -653,7 +653,7 @@ class TestGizmosExtra:
             inertia_gizmos.draw_inertia_gizmos()
 
     def test_inertia_gizmos_tag_redraw_no_wm(self) -> None:
-        """Verify tag_redraw returns early if window_manager is missing (249)."""
+        """Verify tag_redraw returns early if window_manager is missing."""
 
         class MockContextNoWM:
             window_manager = None
@@ -662,7 +662,7 @@ class TestGizmosExtra:
             assert inertia_gizmos.tag_redraw() is None
 
     def test_inertia_gizmos_tag_redraw_non_view3d(self) -> None:
-        """Verify tag_redraw skips non VIEW_3D areas (256->255)."""
+        """Verify tag_redraw skips non VIEW_3D areas."""
 
         class MockArea:
             type = "PROPERTIES"
@@ -683,7 +683,7 @@ class TestGizmosExtra:
             inertia_gizmos.tag_redraw()
 
     def test_inertia_gizmos_check_manual_inertia_scene_exception(self) -> None:
-        """Verify check_manual_inertia_on_load handles scene exceptions gracefully (279-281)."""
+        """Verify check_manual_inertia_on_load handles scene exceptions gracefully."""
 
         class BadContext:
             @property
@@ -694,7 +694,7 @@ class TestGizmosExtra:
             assert inertia_gizmos.check_manual_inertia_on_load() is None
 
     def test_inertia_gizmos_check_manual_inertia_scene_none(self) -> None:
-        """Verify check_manual_inertia_on_load when scene is None (279)."""
+        """Verify check_manual_inertia_on_load when scene is None."""
 
         class MockCtxNoScene:
             scene = None
@@ -703,7 +703,7 @@ class TestGizmosExtra:
             assert inertia_gizmos.check_manual_inertia_on_load() is None
 
     def test_inertia_gizmos_registration_coverage(self) -> None:
-        """Verify register/unregister double call branches (294->300, 308->312, 312->exit)."""
+        """Verify register/unregister handle repeated calls and missing draw handle gracefully."""
         # Register when already registered
         inertia_gizmos.register()
         inertia_gizmos.register()
@@ -742,7 +742,7 @@ class TestGizmosExtra:
         joint_gizmos._builtin_shader_name = None
 
     def test_joint_gizmos_draw_no_prefs(self) -> None:
-        """Verify draw_joint_axes handles Falsy preferences gracefully (200->204)."""
+        """Verify draw_joint_axes handles Falsy preferences gracefully."""
         mock_ctx = MagicMock()
         mock_ctx.scene = None
         with (
@@ -754,7 +754,7 @@ class TestGizmosExtra:
             joint_gizmos.draw_joint_axes()
 
     def test_joint_gizmos_draw_empty_tris_only(self) -> None:
-        """Verify draw_joint_axes with empty tris branch (259->273)."""
+        """Verify draw_joint_axes when generated geometry contains lines but no triangles."""
         mock_ctx = MagicMock()
         mock_scene = MagicMock()
         mock_ctx.scene = mock_scene
@@ -789,7 +789,7 @@ class TestGizmosExtra:
             joint_gizmos.draw_joint_axes()
 
     def test_joint_gizmos_fix_existing_joints_no_scene_attr(self) -> None:
-        """Verify fix_existing_joints handles scene AttributeError gracefully (288-289)."""
+        """Verify fix_existing_joints handles scene AttributeError gracefully."""
 
         class BadContext:
             @property
@@ -800,7 +800,7 @@ class TestGizmosExtra:
             joint_gizmos.fix_existing_joints()
 
     def test_joint_gizmos_fix_existing_joints_no_addon_prefs(self) -> None:
-        """Verify fix_existing_joints handles None addon preferences branch (294->297)."""
+        """Verify fix_existing_joints handles None addon preferences."""
 
         class MockScene:
             objects = []
@@ -817,7 +817,7 @@ class TestGizmosExtra:
             joint_gizmos.fix_existing_joints()
 
     def test_joint_gizmos_fix_existing_joints_none_scene(self) -> None:
-        """Verify fix_existing_joints exits early if scene is None (298)."""
+        """Verify fix_existing_joints exits early if scene is None."""
 
         class MockCtx:
             scene = None
@@ -832,7 +832,7 @@ class TestGizmosExtra:
             joint_gizmos.fix_existing_joints()
 
     def test_joint_gizmos_update_viz_handle_no_wm(self) -> None:
-        """Verify update_viz_handle exits early when window_manager is None (381->exit)."""
+        """Verify update_viz_handle exits early when window_manager is None."""
 
         class MockContextNoWM:
             window_manager = None
@@ -841,7 +841,7 @@ class TestGizmosExtra:
         joint_gizmos.update_viz_handle(MockContextNoWM())
 
     def test_joint_gizmos_update_viz_handle_redundant(self) -> None:
-        """Verify update_viz_handle branch when show_axes is True and current_handler is not None (370->381)."""
+        """Verify update_viz_handle when show_axes is True and handler is already registered."""
 
         class MockArea:
             type = "VIEW_3D"
@@ -873,7 +873,7 @@ class TestGizmosExtra:
             joint_gizmos.update_viz_handle(MockCtx())
 
     def test_joint_gizmos_update_viz_handle_not_in_namespace(self) -> None:
-        """Verify update_viz_handle branch when handler is removed but not in namespace dictionary (377->381)."""
+        """Verify update_viz_handle when handler is removed but not in namespace dictionary."""
 
         class MockArea:
             type = "VIEW_3D"
@@ -914,7 +914,7 @@ class TestGizmosExtra:
             joint_gizmos.update_viz_handle(MockCtx())
 
     def test_joint_gizmos_update_viz_handle_redraw(self) -> None:
-        """Verify update_viz_handle tags 3D areas for redraw (383-385)."""
+        """Verify update_viz_handle tags 3D areas for redraw."""
 
         class MockArea:
             type = "VIEW_3D"
@@ -949,7 +949,7 @@ class TestGizmosExtra:
             assert mock_area.redraw_called
 
     def test_joint_gizmos_registration_coverage(self) -> None:
-        """Verify register/unregister double call and unregister when handler is None (325->329, 335->339, 340->exit, 347->exit)."""
+        """Verify register/unregister handle repeated calls and unregister when handler is None."""
         # Call register twice to test fix_existing_joints already in load_post
         joint_gizmos.register()
         joint_gizmos.register()
@@ -974,7 +974,7 @@ class TestGizmosExtra:
             joint_gizmos.unregister()
 
     def test_joint_gizmos_update_viz_handle_non_view3d_area(self) -> None:
-        """Verify update_viz_handle when an area is not VIEW_3D (383->382)."""
+        """Verify update_viz_handle when an area is not VIEW_3D."""
 
         class MockArea:
             type = "PROPERTIES"

--- a/tests/unit/platforms/blender/test_joints.py
+++ b/tests/unit/platforms/blender/test_joints.py
@@ -402,7 +402,7 @@ class TestJointOperations:
         assert not LINKFORGE_OT_auto_detect_parent_child.poll(bpy.context)
 
     def test_create_joint_mesh_no_parent_link(self, scene, blender_context) -> None:
-        """Test create joint when active object is not a link and has no parent link (69->72)."""
+        """Test create joint when active object is not a link and has no parent link."""
         mesh_obj = create_test_object("non_link_mesh", None, scene)
         assert bpy.context.view_layer is not None
         bpy.context.view_layer.objects.active = mesh_obj

--- a/tests/unit/platforms/blender/test_link_ops.py
+++ b/tests/unit/platforms/blender/test_link_ops.py
@@ -520,7 +520,7 @@ class TestRealtimePreviewsAndDebounce:
         lf = safe_get_linkforge(link_obj)
         lf.collision_quality = 50.0
 
-        # Scenario 1: Decimate modifier exists
+        # Existing Decimate modifier update
         col_obj.modifiers._items.clear()
         decimate_mod = col_obj.modifiers.new(name="Decimate", type="DECIMATE")
         decimate_mod.type = "DECIMATE"
@@ -530,7 +530,7 @@ class TestRealtimePreviewsAndDebounce:
         update_collision_quality_realtime(link_obj, col_obj)
         assert decimate_mod.ratio == 0.5
 
-        # Scenario 2: Decimate modifier is missing but object is MESH (adds it)
+        # Missing Decimate modifier creation on mesh object
         col_obj.modifiers.remove(decimate_mod)
 
         getattr(col_obj, PROP_GEOM).collision_quality = 30.0
@@ -784,7 +784,7 @@ class TestLinkRobustness:
             link_ops._preview_last_request_time = 0
             assert execute_collision_preview_update() is None
 
-        # TAG_IMPORTED_SOURCE branch
+        # Verify handling with imported source tag present
         with patch(
             "linkforge.blender.adapters.blender_to_core.detect_primitive_type"
         ) as mock_detect:
@@ -814,7 +814,7 @@ class TestLinkRobustness:
         link_obj = create_robot_link("NoVisLink", scene, with_visual=False, with_collision=False)
         assert create_collision_for_link(link_obj, "box", bpy.context) is None
 
-        # Compound logic branches
+        # Verify collision creation for link with multiple visual meshes
         link_obj = create_robot_link("CompLink", scene)
         vis1 = create_mesh_object("CompLink_visual_1", scene)
         vis1.parent = link_obj

--- a/tests/unit/platforms/blender/test_mesh_io.py
+++ b/tests/unit/platforms/blender/test_mesh_io.py
@@ -15,6 +15,7 @@ from linkforge.blender.adapters.mesh_io import (
     get_mesh_filename,
 )
 from linkforge.core._utils.path_utils import resolve_package_path
+from mathutils import Vector
 
 from tests.blender_test_utils import create_mesh_object, create_test_object
 
@@ -408,7 +409,7 @@ class TestMeshExhaustiveCoverage:
         assert offset.is_identity
 
     def test_export_mesh_glb_generic_exception(self, mocker, scene, tmp_path) -> None:
-        """Verify GLB export generic unexpected Exception is caught and propagated (covers line 253-255)."""
+        """Verify GLB export generic unexpected Exception is caught and propagated."""
         obj = create_mesh_object("glb_generic_err_mesh", scene=scene, with_cube=True)
         filepath = tmp_path / "test.glb"
 
@@ -420,9 +421,7 @@ class TestMeshExhaustiveCoverage:
             export_mesh_glb(obj, filepath)
 
     def test_export_link_mesh_simplification_returns_none(self, mocker, scene, tmp_path) -> None:
-        """Verify export_link_mesh handles create_simplified_mesh returning None (covers 370->374 false branch)."""
-        from mathutils import Vector
-
+        """Verify export_link_mesh handles create_simplified_mesh returning None."""
         obj = create_mesh_object("simplify_none_mesh", scene=scene, with_cube=True)
         obj.bound_box = [Vector((1.0, 1.0, 1.0))] * 8
 
@@ -441,7 +440,7 @@ class TestMeshExhaustiveCoverage:
         assert filepath is not None
 
     def test_export_link_mesh_finally_cleanup_no_data(self, mocker, scene, tmp_path) -> None:
-        """Verify finally cleanup block when simplified_obj.data and temp_export_obj.data are None (covers 403->405 and 409->411 false branches)."""
+        """Verify finally cleanup block when simplified_obj.data and temp_export_obj.data are None."""
         obj = create_mesh_object("no_data_mesh", scene=scene, with_cube=True)
 
         mocker.patch("linkforge.blender.adapters.mesh_io.bpy.ops.object.modifier_apply")

--- a/tests/unit/platforms/blender/test_name_sync_handler.py
+++ b/tests/unit/platforms/blender/test_name_sync_handler.py
@@ -55,9 +55,9 @@ def test_on_depsgraph_update_post_all_branches(scene):
     """Verify both True and False branches for all component synchronizations in the depsgraph handler."""
     cleanup_blender_scene(scene)
 
-    # We need:
-    # - Updates that trigger TRUE branch (sanitized != current)
-    # - Updates that trigger FALSE branch (sanitized == current)
+    # Test cases:
+    # - Updates that require sanitization (sanitized != current)
+    # - Updates already sanitized (sanitized == current)
 
     link_true = create_test_object("link_true", None, scene=scene)
     lp_true = safe_get_linkforge(link_true, scene)

--- a/tests/unit/platforms/blender/test_panels.py
+++ b/tests/unit/platforms/blender/test_panels.py
@@ -672,7 +672,7 @@ class TestControlPanel:
         props.ros2_control_active_joint_index = 5
         panel.draw(bpy.context)
 
-        # Reset active index and add parameters to cover 139-157
+        # Reset active index and add parameters to test joint parameters display
         props.ros2_control_active_joint_index = 0
         active_joint = props.ros2_control_joints[0]
         active_joint.parameters.prop_type = Ros2ControlParameterProperty
@@ -682,7 +682,7 @@ class TestControlPanel:
         active_joint.show_parameters = True
         panel.draw(bpy.context)
 
-        # Clear global parameters to cover 192->215 False
+        # Clear global parameters to test drawing when parameter list is empty
         props.ros2_control_parameters.clear()
         panel.draw(bpy.context)
 
@@ -705,7 +705,7 @@ class TestControlPanel:
             0,
         )
 
-        # UIList draw_item with DEFAULT layout and empty interfaces to cover (67->exit True)
+        # UIList draw_item with DEFAULT layout and empty interfaces
         ul.layout_type = "DEFAULT"
         ul.draw_item(
             bpy.context,
@@ -719,7 +719,7 @@ class TestControlPanel:
             0,
         )
 
-        # UIList draw_item with UNKNOWN layout type to cover (70->exit True)
+        # UIList draw_item with UNKNOWN layout type
         ul.layout_type = "UNKNOWN"
         ul.draw_item(
             bpy.context,

--- a/tests/unit/platforms/blender/test_panels.py
+++ b/tests/unit/platforms/blender/test_panels.py
@@ -276,23 +276,23 @@ class TestForgePanel:
         mock_ctx.scene = None
         assert panel.draw(mock_ctx) is None
 
-        # box is None branch check
+        # Verify fallback when layout box is None
         props = safe_get_linkforge_scene(scene)
         props.is_importing = True
         mock_layout.box.return_value = None
         panel.draw(bpy.context)
 
-        # row is None branch check inside importing (first row is None)
+        # Verify fallback when first row is None while importing
         mock_layout.box.return_value = mock_layout
         mock_layout.row.side_effect = None
         mock_layout.row.return_value = None
         panel.draw(bpy.context)
 
-        # row is None branch check inside importing (second row is None)
+        # Verify fallback when second row is None while importing
         mock_layout.row.side_effect = [mock_layout, None]
         panel.draw(bpy.context)
 
-        # row is None branch check inside non-importing
+        # Verify fallback when row is None while not importing
         props.is_importing = False
         mock_layout.row.side_effect = None
         mock_layout.row.return_value = None
@@ -748,7 +748,7 @@ class TestControlPanel:
             0,
         )
 
-        # Menu draw edge cases and already-added branch
+        # Menu draw edge cases and existing joint handling
         menu = LINKFORGE_MT_add_control_joint()
 
         # Context layout and scene None checks

--- a/tests/unit/platforms/blender/test_properties.py
+++ b/tests/unit/platforms/blender/test_properties.py
@@ -928,7 +928,7 @@ class TestGlobalPropertiesAndCallbacks:
         update_sensor_hierarchy(sp, bpy.context)
         assert sensor_obj.parent is None
 
-        # update_sensor_hierarchy reparenting when attached link is present (line 130-137)
+        # update_sensor_hierarchy reparenting when attached link is present
         link_obj = create_robot_link("attached_link_obj", scene)
         with (
             patch(
@@ -941,7 +941,7 @@ class TestGlobalPropertiesAndCallbacks:
             assert mock_set_parent.called
             assert mock_sync_coll.called
 
-        # update_sensor_hierarchy when already parented to link_obj (branch 130->135)
+        # update_sensor_hierarchy when already parented to link_obj
         sensor_obj.parent = link_obj
         with (
             patch(

--- a/tests/unit/platforms/blender/test_properties.py
+++ b/tests/unit/platforms/blender/test_properties.py
@@ -285,7 +285,7 @@ class TestGlobalPropertiesAndCallbacks:
 
         original_id_data = getattr(props, "id_data", None)
         try:
-            # Clear id_data to bypass Strategy 1 and test fallbacks
+            # Clear id_data to test fallback resolution without direct data-block reference
             props.id_data = None
 
             mock_ctx = MagicMock()
@@ -295,7 +295,7 @@ class TestGlobalPropertiesAndCallbacks:
             owner = find_property_owner(mock_ctx, props, PROP_LINK)
             assert owner == obj1
 
-            # Strategy 2: Active Object check
+            # Fallback resolution via active object
             mock_ctx_obj = MagicMock()
             mock_ctx_obj.object = obj1
             owner_obj = find_property_owner(mock_ctx_obj, props, PROP_LINK)
@@ -309,7 +309,7 @@ class TestGlobalPropertiesAndCallbacks:
             owner_scene = find_property_owner(mock_ctx_scene, props, PROP_LINK)
             assert owner_scene == obj1
 
-            # Strategy 4 Fallback to None
+            # Fallback resolution returning None when no matching object exists
             mock_ctx_none = MagicMock()
             mock_ctx_none.object = None
             mock_ctx_none.selected_objects = []

--- a/tests/unit/platforms/blender/test_scene_utils.py
+++ b/tests/unit/platforms/blender/test_scene_utils.py
@@ -340,7 +340,7 @@ class TestSceneAnalysis:
         assert stats.geometry_stats["link_geom_mesh"][1] == GEOM_MESH
         assert link_obj in stats.manual_inertia_objects
 
-        # Joint props Falsy branches in loop
+        # Evaluate joint without child link assigned
         joint_obj = create_test_object("joint_empty", None, scene)
         joint_obj.type = "EMPTY"
         safe_get_joint(joint_obj).is_robot_joint = True
@@ -573,7 +573,7 @@ class TestCollectionManagement:
         assert col2 in obj.users_collection
         assert col1 not in obj.users_collection
 
-        # Call move_to_collection again when already in col2 to cover "already there" branch
+        # Call move_to_collection again when already present in target collection
         move_to_collection(obj, col2)
 
         # Null check safety

--- a/tests/unit/platforms/blender/test_translator.py
+++ b/tests/unit/platforms/blender/test_translator.py
@@ -1,5 +1,6 @@
 import contextlib
-from unittest.mock import MagicMock, patch
+import types
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import bpy
 import pytest
@@ -13,12 +14,17 @@ from linkforge.blender.adapters.translator import (
     TransmissionTranslator,
 )
 from linkforge.core import (
+    Box,
+    Joint,
+    JointType,
     RobotBuilder,
     RobotValidationError,
     SensorType,
     ValidationErrorCode,
     ValidationResult,
+    Vector3,
 )
+from mathutils import Matrix
 
 from tests.blender_test_utils import (
     cleanup_blender_scene,
@@ -26,6 +32,7 @@ from tests.blender_test_utils import (
     create_test_object,
     safe_get_joint,
     safe_get_linkforge,
+    safe_get_linkforge_scene,
     safe_get_sensor,
     safe_get_transmission,
 )
@@ -296,55 +303,45 @@ def test_ros2_control_translator_uncovered_branches(scene, blender_context):
 
     assert translator._blender_ros2_control_to_core(None) is None
 
-    class FakeProps:
-        use_ros2_control = False
+    props = safe_get_linkforge_scene(scene)
+    props.use_ros2_control = False
+    assert translator._blender_ros2_control_to_core(props) is None
 
-    assert translator._blender_ros2_control_to_core(FakeProps()) is None
-
-    class BrokenProps:
-        use_ros2_control = True
-
-        @property
-        def ros2_control_type(self):
-            raise RuntimeError("Broken ros2 control")
+    broken_props = MagicMock(use_ros2_control=True)
+    type(broken_props).ros2_control_type = PropertyMock(
+        side_effect=RuntimeError("Broken ros2 control")
+    )
 
     val_result = ValidationResult(robot_name="test_robot")
-    translator.translate(BrokenProps(), builder, blender_context, validation_result=val_result)
+    translator.translate(broken_props, builder, blender_context, validation_result=val_result)
     assert len(val_result.errors) == 1
     assert "ROS2 Control translation failed" in val_result.errors[0].title
 
-    # 2b. Translate exception caught with validation_result=None (swallowed/ignored)
-    translator.translate(BrokenProps(), builder, blender_context, validation_result=None)
+    # Translate exception caught with validation_result=None (swallowed/ignored)
+    translator.translate(broken_props, builder, blender_context, validation_result=None)
 
-    # 2c. Translate valid system hardware type with state_ifs but no cmd_ifs to cover fallbacks
-    class MockControlJointSystem:
-        def __init__(self, name, state_only=True):
-            self.name = name
-            self.cmd_position = not state_only
-            self.cmd_velocity = False
-            self.cmd_effort = False
-            self.state_position = bool(state_only)
-            self.state_velocity = False
-            self.state_effort = False
-            self.parameters = []
-            self.joint_obj = None
+    # Translate valid system hardware type with state interfaces but no command interfaces fallback
+    props.use_ros2_control = True
+    props.ros2_control_name = ""  # Cover empty ros2_control_name fallback to "RobotControl"
+    props.ros2_control_type = "system"
+    props.hardware_plugin = "mock_plugin"
+    props.ros2_control_joints.clear()
 
-    class MockControlPropsSystem:
-        use_ros2_control = True
-        ros2_control_name = ""  # Cover empty ros2_control_name fallback to "RobotControl"
-        ros2_control_type = "system"
-        hardware_plugin = "mock_plugin"
-        ros2_control_joints = [
-            MockControlJointSystem("joint_sys1", state_only=True),
-            MockControlJointSystem("joint_sys2", state_only=False),
-        ]
+    item_sys1 = props.ros2_control_joints.add()
+    item_sys1.name = "joint_sys1"
+    item_sys1.cmd_position = False
+    item_sys1.state_position = True
 
-    # 2c. Translate valid system hardware type with state_ifs but no cmd_ifs to cover fallbacks
+    item_sys2 = props.ros2_control_joints.add()
+    item_sys2.name = "joint_sys2"
+    item_sys2.cmd_position = True
+    item_sys2.state_position = False
+
     builder.link("link_p1").commit()
     builder.link("link_c1", parent="link_p1", joint_name="joint_sys1").commit()
     builder.link("link_c2", parent="link_p1", joint_name="joint_sys2").commit()
 
-    translator.translate(MockControlPropsSystem(), builder, blender_context)
+    translator.translate(props, builder, blender_context)
     assert builder.robot.get_ros2_control("RobotControl") is not None
     assert list(builder.robot.get_ros2_control("RobotControl").joints[0].command_interfaces) == [
         "position"
@@ -353,110 +350,78 @@ def test_ros2_control_translator_uncovered_branches(scene, blender_context):
         "position"
     ]
 
-    # 2d. ROS2 Control: joint_obj present, joint_props.joint_name is non-string → fallback to item.name
-    #     When item.name is also None → final fallback becomes "joint"
-    class MockJointPropsNonStr:
-        joint_name = 123  # non-string
-
-    class MockControlJointWithObj:
-        def __init__(self, name, joint_obj):
-            self.name = name
-            self.cmd_position = True
-            self.state_position = True
-            self.cmd_velocity = False
-            self.cmd_effort = False
-            self.state_velocity = False
-            self.state_effort = False
-            self.parameters = []
-            self.joint_obj = joint_obj
-
+    # ROS2 Control: joint_obj present, joint_props.joint_name is non-string → fallback to item.name
+    # When item.name is also None → final fallback becomes "joint"
     joint_obj_non_str = create_test_object("joint_sys_non_str_obj2", None, scene=scene)
 
-    # item.name = None → not isinstance(None, str) → fallback to "joint"
-    class MockControlPropsWithObj:
-        use_ros2_control = True
-        ros2_control_name = "obj_control"
-        ros2_control_type = "system"
-        hardware_plugin = "mock_plugin"
-        ros2_control_joints = [MockControlJointWithObj(None, joint_obj_non_str)]
+    mock_joint_item = MagicMock()
+    mock_joint_item.name = None
+    mock_joint_item.joint_obj = joint_obj_non_str
+    mock_joint_item.cmd_position = True
+    mock_joint_item.state_position = True
+    mock_joint_item.cmd_velocity = False
+    mock_joint_item.cmd_effort = False
+    mock_joint_item.state_velocity = False
+    mock_joint_item.state_effort = False
+    mock_joint_item.parameters = []
+
+    mock_props = MagicMock()
+    mock_props.use_ros2_control = True
+    mock_props.ros2_control_name = "obj_control"
+    mock_props.ros2_control_type = "system"
+    mock_props.hardware_plugin = "mock_plugin"
+    mock_props.ros2_control_joints = [mock_joint_item]
 
     with patch(
         "linkforge.blender.adapters.translator.get_joint_props",
-        return_value=MockJointPropsNonStr(),
+        return_value=types.SimpleNamespace(joint_name=123),
     ):
-        control_obj = translator._blender_ros2_control_to_core(MockControlPropsWithObj())
+        control_obj = translator._blender_ros2_control_to_core(mock_props)
     assert control_obj is not None
     assert control_obj.joints[0].name == "joint"
 
-    class MockControlJoint:
-        def __init__(self, name):
-            self.name = name
-            self.cmd_position = True
-            self.state_position = False
-            self.cmd_velocity = False
-            self.cmd_effort = False
-            self.state_velocity = False
-            self.state_effort = False
-            self.parameters = []
-            self.joint_obj = None
+    props.ros2_control_name = "sensor_control"
+    props.ros2_control_type = "sensor"
+    props.hardware_plugin = "mock_plugin"
+    props.ros2_control_joints.clear()
+    item_sensor = props.ros2_control_joints.add()
+    item_sensor.name = "joint_1"
+    item_sensor.cmd_position = True
+    item_sensor.state_position = False
 
-    class MockControlProps:
-        use_ros2_control = True
-        ros2_control_name = "sensor_control"
-        ros2_control_type = "sensor"
-        hardware_plugin = "mock_plugin"
-        ros2_control_joints = [MockControlJoint("joint_1")]
-
-    control = translator._blender_ros2_control_to_core(MockControlProps())
+    control = translator._blender_ros2_control_to_core(props)
     assert control is not None
     assert len(control.joints[0].command_interfaces) == 0
     assert "position" in control.joints[0].state_interfaces
 
-    class MockControlJointEmpty:
-        def __init__(self, name):
-            self.name = name
-            self.cmd_position = False
-            self.cmd_velocity = False
-            self.cmd_effort = False
-            self.state_position = False
-            self.state_velocity = False
-            self.state_effort = False
-            self.parameters = []
-            self.joint_obj = None
+    props.ros2_control_name = "empty_control"
+    props.ros2_control_type = "system"
+    props.ros2_control_joints.clear()
+    item_empty = props.ros2_control_joints.add()
+    item_empty.name = "joint_empty"
+    item_empty.cmd_position = False
+    item_empty.cmd_velocity = False
+    item_empty.cmd_effort = False
+    item_empty.state_position = False
+    item_empty.state_velocity = False
+    item_empty.state_effort = False
 
-    class MockControlPropsEmpty:
-        use_ros2_control = True
-        ros2_control_name = "empty_control"
-        ros2_control_type = "system"
-        hardware_plugin = "mock_plugin"
-        ros2_control_joints = [MockControlJointEmpty("joint_empty")]
-
-    control_empty = translator._blender_ros2_control_to_core(MockControlPropsEmpty())
+    control_empty = translator._blender_ros2_control_to_core(props)
     assert control_empty is None
 
-    class MockControlJointActuator:
-        def __init__(self, name):
-            self.name = name
-            self.cmd_position = True
-            self.state_position = True
-            self.cmd_velocity = False
-            self.cmd_effort = False
-            self.state_velocity = False
-            self.state_effort = False
-            self.parameters = []
-            self.joint_obj = None
+    props.ros2_control_name = "actuator_control"
+    props.ros2_control_type = "actuator"
+    props.ros2_control_joints.clear()
+    item_act1 = props.ros2_control_joints.add()
+    item_act1.name = "joint_1"
+    item_act1.cmd_position = True
+    item_act1.state_position = True
+    item_act2 = props.ros2_control_joints.add()
+    item_act2.name = "joint_2"
+    item_act2.cmd_position = True
+    item_act2.state_position = True
 
-    class MockControlPropsActuator:
-        use_ros2_control = True
-        ros2_control_name = "actuator_control"
-        ros2_control_type = "actuator"
-        hardware_plugin = "mock_plugin"
-        ros2_control_joints = [
-            MockControlJointActuator("joint_1"),
-            MockControlJointActuator("joint_2"),
-        ]
-
-    control_actuator = translator._blender_ros2_control_to_core(MockControlPropsActuator())
+    control_actuator = translator._blender_ros2_control_to_core(props)
     assert control_actuator is not None
     assert len(control_actuator.joints) == 1
     assert control_actuator.joints[0].name == "joint_1"
@@ -471,10 +436,9 @@ def test_transmission_translator_uncovered_branches(scene, blender_context):
 
     assert translator._blender_transmission_to_core(None) is None
 
-    class FakeTransProps:
-        is_robot_transmission = False
-
-    assert translator._blender_transmission_to_core(FakeTransProps()) is None
+    trans_obj_disabled = create_test_object("trans_disabled", None, scene=scene)
+    safe_get_transmission(trans_obj_disabled, scene).is_robot_transmission = False
+    assert translator._blender_transmission_to_core(trans_obj_disabled) is None
 
     trans_obj = create_test_object("test_trans", None, scene=scene)
     tp = safe_get_transmission(trans_obj, scene)
@@ -502,41 +466,34 @@ def test_transmission_translator_uncovered_branches(scene, blender_context):
     assert trans_model.joints[0].name == "joint_without_custom_name"
     assert trans_model.actuators[0].name == "joint_without_custom_name_motor"
 
-    # 3b. Simple transmission when joint_props is None (via mocking property helper)
+    # Simple transmission when joint_props is None (via mocking property helper)
     with patch("linkforge.blender.adapters.translator.get_joint_props", return_value=None):
         trans_model_fallback = translator._blender_transmission_to_core(simple_trans_obj)
         assert trans_model_fallback is not None
         assert trans_model_fallback.joints[0].name == "joint_without_custom_name"
 
-    # 3c. Simple transmission when joint_props.joint_name is a non-string object
+    # Simple transmission when joint_props.joint_name is a non-string object
     jp.joint_name = 123  # type: ignore
     trans_model_non_str = translator._blender_transmission_to_core(simple_trans_obj)
     assert trans_model_non_str is not None
     assert trans_model_non_str.joints[0].name == "joint_without_custom_name"
 
-    class BrokenTransProps:
-        @property
-        def linkforge_transmission(self):
-            class BrokenProps:
-                is_robot_transmission = True
-
-                @property
-                def transmission_type(self):
-                    raise RuntimeError("Broken transmission type")
-
-            return BrokenProps()
-
-        @property
-        def name(self):
-            return "broken_trans"
+    broken_trans_obj = MagicMock()
+    broken_trans_obj.name = "broken_trans"
+    type(broken_trans_obj.linkforge_transmission).is_robot_transmission = PropertyMock(
+        return_value=True
+    )
+    type(broken_trans_obj.linkforge_transmission).transmission_type = PropertyMock(
+        side_effect=RuntimeError("Broken transmission type")
+    )
 
     val_result = ValidationResult(robot_name="test_robot")
-    translator.translate(BrokenTransProps(), builder, blender_context, validation_result=val_result)
+    translator.translate(broken_trans_obj, builder, blender_context, validation_result=val_result)
     assert len(val_result.errors) == 1
     assert "Transmission translation failed: broken_trans" in val_result.errors[0].title
 
-    # 4b. Translate exception with validation_result=None (swallowed/ignored)
-    translator.translate(BrokenTransProps(), builder, blender_context, validation_result=None)
+    # Translate exception with validation_result=None (swallowed/ignored)
+    translator.translate(broken_trans_obj, builder, blender_context, validation_result=None)
 
     j1_obj = create_test_object("joint1_obj", None, scene=scene)
     j1_p = safe_get_joint(j1_obj, scene)
@@ -581,39 +538,35 @@ def test_transmission_translator_uncovered_branches(scene, blender_context):
 
 
 def test_ros2_control_sensor_type_no_cmd_ifs(scene, blender_context):
-    """Cover sensor hardware type branch when cmd_ifs is empty (670->676) and state_ifs already set (676->685)."""
+    """Cover sensor hardware type branch when cmd_ifs is empty and state_ifs already set."""
     cleanup_blender_scene(scene)
 
     translator = Ros2ControlTranslator()
 
-    # Case A: sensor type with NO command interfaces AND existing state_ifs (should NOT add default)
-    class MockJointSensorStateOnly:
-        name = "joint_s"
-        cmd_position = False
-        cmd_velocity = False
-        cmd_effort = False
-        state_position = True  # state already set
-        state_velocity = False
-        state_effort = False
-        parameters = []
-        joint_obj = None
+    props = safe_get_linkforge_scene(scene)
+    props.use_ros2_control = True
+    props.ros2_control_name = "sensor_state_only"
+    props.ros2_control_type = "sensor"
+    props.hardware_plugin = "mock_plugin"
+    props.ros2_control_joints.clear()
 
-    class MockPropsSensorStateOnly:
-        use_ros2_control = True
-        ros2_control_name = "sensor_state_only"
-        ros2_control_type = "sensor"
-        hardware_plugin = "mock_plugin"
-        ros2_control_joints = [MockJointSensorStateOnly()]
+    item = props.ros2_control_joints.add()
+    item.name = "joint_s"
+    item.cmd_position = False
+    item.cmd_velocity = False
+    item.cmd_effort = False
+    item.state_position = True
+    item.state_velocity = False
+    item.state_effort = False
 
-    result = translator._blender_ros2_control_to_core(MockPropsSensorStateOnly())
+    result = translator._blender_ros2_control_to_core(props)
     assert result is not None
-    # state_ifs already had "position", should not double-add
     assert list(result.joints[0].state_interfaces) == ["position"]
     assert list(result.joints[0].command_interfaces) == []
 
 
 def test_joint_translator_planar_type_axis(scene, blender_context):
-    """Cover JointType.PLANAR joint branch (404->408 false path is the default after PLANAR executes)."""
+    """Verify translating a JointType.PLANAR joint."""
     cleanup_blender_scene(scene)
 
     translator = JointTranslator()
@@ -642,8 +595,7 @@ def test_joint_translator_planar_type_axis(scene, blender_context):
 def test_transmission_custom_type(scene, blender_context):
     """Cover CUSTOM transmission type (raw_type in TRANS_CUSTOM path, not DIFFERENTIAL).
 
-    This also covers branch 815->849 (elif DIFFERENTIAL is False) and branch 794->797
-    (joint_props.joint_name IS a valid string, so no fallback needed).
+    Also verifies joint_props.joint_name when it is a valid string (no fallback needed).
     """
     cleanup_blender_scene(scene)
 
@@ -671,9 +623,6 @@ def test_transmission_custom_type(scene, blender_context):
 def test_link_translator_comprehensive(scene, blender_context):
     """Cover visual/collision successful translation pathways, manual inertia, and simulation props."""
     cleanup_blender_scene(scene)
-
-    from linkforge.core import Box, Vector3
-    from mathutils import Matrix
 
     translator = LinkTranslator()
     builder = RobotBuilder("test_robot")
@@ -748,9 +697,6 @@ def test_link_translator_comprehensive(scene, blender_context):
 def test_joint_translator_comprehensive(scene, blender_context):
     """Cover all remaining JointTranslator branches (early exits, validation, axes, dynamics, safety, calibration)."""
     cleanup_blender_scene(scene)
-
-    from linkforge.core import RobotValidationError
-    from mathutils import Matrix
 
     translator = JointTranslator()
     builder = RobotBuilder("test_joint_robot")
@@ -955,32 +901,31 @@ def test_joint_translator_comprehensive(scene, blender_context):
     jp6.joint_type = "PLANAR"
     jp6.axis = "Z"
 
-    class FakeJointProps:
-        is_robot_joint = True
-        parent_link = parent_obj
-        child_link = unrecognized_child_obj
-        joint_name = "unrecognized_joint"
-        joint_type = "fake_joint_type"
-        axis = "Z"
-        limit_lower = 0.0
-        limit_upper = 0.0
-        limit_effort = 0.0
-        limit_velocity = 0.0
-        mimic_joint = None
-        safety_k_position = 0.0
-        safety_k_velocity = 0.0
-        safety_soft_lower = 0.0
-        safety_soft_upper = 0.0
-        calibration_rising = 0.0
-        calibration_falling = 0.0
-        dynamics_damping = 0.0
-        dynamics_friction = 0.0
-
-    from unittest.mock import patch
+    fake_joint_props = types.SimpleNamespace(
+        is_robot_joint=True,
+        parent_link=parent_obj,
+        child_link=unrecognized_child_obj,
+        joint_name="unrecognized_joint",
+        joint_type="fake_joint_type",
+        axis="Z",
+        limit_lower=0.0,
+        limit_upper=0.0,
+        limit_effort=0.0,
+        limit_velocity=0.0,
+        mimic_joint=None,
+        safety_k_position=0.0,
+        safety_k_velocity=0.0,
+        safety_soft_lower=0.0,
+        safety_soft_upper=0.0,
+        calibration_rising=0.0,
+        calibration_falling=0.0,
+        dynamics_damping=0.0,
+        dynamics_friction=0.0,
+    )
 
     with (
         patch(
-            "linkforge.blender.adapters.translator.get_joint_props", return_value=FakeJointProps()
+            "linkforge.blender.adapters.translator.get_joint_props", return_value=fake_joint_props
         ),
         patch("linkforge.blender.adapters.translator.JointType", return_value="fake_joint_type"),
         contextlib.suppress(Exception),
@@ -991,9 +936,6 @@ def test_joint_translator_comprehensive(scene, blender_context):
 def test_sensor_translator_comprehensive(scene, blender_context):
     """Cover all remaining SensorTranslator branches (early exits, matrix correction, all sensor types, noise, plugins)."""
     cleanup_blender_scene(scene)
-
-    from linkforge.core.models.sensor import SensorType
-    from mathutils import Matrix
 
     translator = SensorTranslator()
     builder = RobotBuilder("test_sensor_robot")
@@ -1114,7 +1056,7 @@ def test_sensor_translator_comprehensive(scene, blender_context):
     assert builder.robot.sensors[0].contact_info is not None
     assert builder.robot.sensors[0].contact_info.collision == "parent_link_name_collision"
 
-    # 7b. Test CONTACT sensor type with custom collision name
+    # Test CONTACT sensor type with custom collision name
     cleanup_blender_scene(scene)
     builder = RobotBuilder("test_sensor_robot_5_custom")
     builder.link("parent_link_name").commit()
@@ -1157,7 +1099,7 @@ def test_sensor_translator_comprehensive(scene, blender_context):
     assert len(val_res.errors) == 1
     assert "Sensor translation failed" in val_res.errors[0].title
 
-    # 9b. Cover early exit 452->exit
+    # Cover early exit when object is None
     translator.translate(None, builder, blender_context)
 
     cleanup_blender_scene(scene)
@@ -1171,22 +1113,24 @@ def test_sensor_translator_comprehensive(scene, blender_context):
     sp_fake.sensor_type = "CAMERA"
     sp_fake.attached_link = link_obj
 
-    class FakeProps:
-        is_robot_sensor = True
-        sensor_name = "fake_sensor"
-        sensor_type = "fake_type"
-        attached_link = link_obj
-        use_noise = False
-        use_gazebo_plugin = False
-        topic_name = ""
-        update_rate = 10.0
-        always_on = True
-        visualize = False
-
-    from unittest.mock import patch
+    fake_sensor_props = types.SimpleNamespace(
+        is_robot_sensor=True,
+        sensor_name="fake_sensor",
+        sensor_type="fake_type",
+        attached_link=link_obj,
+        use_noise=False,
+        use_gazebo_plugin=False,
+        topic_name="",
+        update_rate=10.0,
+        always_on=True,
+        visualize=False,
+    )
 
     with (
-        patch("linkforge.blender.adapters.translator.get_sensor_props", return_value=FakeProps()),
+        patch(
+            "linkforge.blender.adapters.translator.get_sensor_props",
+            return_value=fake_sensor_props,
+        ),
         patch("linkforge.blender.adapters.translator.SensorType", return_value="fake_type"),
     ):
         translator.translate(sp_fake_obj, builder, blender_context)
@@ -1202,15 +1146,12 @@ def test_ros2_control_translator_comprehensive(scene, blender_context):
     assert translator._blender_ros2_control_to_core(None) is None
     translator.translate(None, builder, blender_context)
 
-    from unittest.mock import MagicMock
-
-    props = MagicMock()
+    props = safe_get_linkforge_scene(scene)
     props.use_ros2_control = True
     props.ros2_control_type = "system"
     props.ros2_control_name = "TestSystemControl"
     props.hardware_plugin = "mock_plugin"
-
-    from linkforge.core.models.joint import Joint, JointType
+    props.ros2_control_joints.clear()
 
     builder.robot._joint_index["joint_one_name"] = Joint(
         name="joint_one_name",
@@ -1230,7 +1171,7 @@ def test_ros2_control_translator_comprehensive(scene, blender_context):
     j1_p.is_robot_joint = True
     j1_p.joint_name = "joint_one_name"
 
-    item1 = MagicMock()
+    item1 = props.ros2_control_joints.add()
     item1.cmd_position = True
     item1.cmd_velocity = True
     item1.cmd_effort = True
@@ -1238,10 +1179,9 @@ def test_ros2_control_translator_comprehensive(scene, blender_context):
     item1.state_velocity = True
     item1.state_effort = True
     item1.joint_obj = j1_obj
-    item1.parameters = []
 
     # Joint 2 with fallback joint name
-    item2 = MagicMock()
+    item2 = props.ros2_control_joints.add()
     item2.cmd_position = True
     item2.cmd_velocity = False
     item2.cmd_effort = False
@@ -1250,9 +1190,6 @@ def test_ros2_control_translator_comprehensive(scene, blender_context):
     item2.state_effort = False
     item2.joint_obj = None
     item2.name = "joint_two_fallback"
-    item2.parameters = []
-
-    props.ros2_control_joints = [item1, item2]
 
     # Translate
     translator.translate(props, builder, blender_context)
@@ -1274,8 +1211,6 @@ def test_transmission_translator_comprehensive(scene, blender_context):
     builder = RobotBuilder("test_trans_robot")
 
     assert translator._blender_transmission_to_core(None) is None
-
-    from linkforge.core.models.joint import Joint, JointType
 
     builder.robot._joint_index["joint_to_transmit"] = Joint(
         name="joint_to_transmit",
@@ -1309,7 +1244,7 @@ def test_transmission_translator_comprehensive(scene, blender_context):
     assert trans.joints[0].name == "joint_to_transmit"
     assert trans.actuators[0].name == "my_custom_actuator"
 
-    # 2b. Simple/Custom transmission where potential_name is not a string (covers 794->797)
+    # Simple/Custom transmission where potential_name is not a string
     builder.robot._joint_index["trans_joint_non_str"] = Joint(
         name="trans_joint_non_str",
         type=JointType.FIXED,
@@ -1325,13 +1260,9 @@ def test_transmission_translator_comprehensive(scene, blender_context):
     tp_non_str.transmission_type = "SIMPLE"
     tp_non_str.joint_name = joint_obj_non_str
 
-    class FakeJointPropsNonStr:
-        joint_name = 123
-
-    from unittest.mock import patch
-
     with patch(
-        "linkforge.blender.adapters.translator.get_joint_props", return_value=FakeJointPropsNonStr()
+        "linkforge.blender.adapters.translator.get_joint_props",
+        return_value=types.SimpleNamespace(joint_name=123),
     ):
         translator.translate(trans_obj_non_str, builder, blender_context)
 
@@ -1356,3 +1287,30 @@ def test_transmission_translator_comprehensive(scene, blender_context):
     tp_invalid.transmission_type = "INVALID_TYPE"
 
     assert translator._blender_transmission_to_core(trans_obj_invalid) is None
+
+
+def test_ros2_control_translator_missing_joint(scene, blender_context) -> None:
+    """Verify that orphaned joints in ROS 2 Control produce a validation error and are not added to the robot."""
+    cleanup_blender_scene(scene)
+
+    props = safe_get_linkforge_scene(scene)
+    props.use_ros2_control = True
+    props.ros2_control_name = "MissingJointControl"
+    props.ros2_control_joints.clear()
+
+    item = props.ros2_control_joints.add()
+    item.name = "nonexistent_joint"
+    item.cmd_position = True
+    item.state_position = True
+
+    builder = RobotBuilder("test_robot")
+    builder.link("base_link").commit()
+
+    translator = Ros2ControlTranslator()
+    val_result = ValidationResult(robot_name="test_robot")
+    translator.translate(props, builder, blender_context, validation_result=val_result)
+
+    assert len(val_result.errors) == 1
+    assert val_result.errors[0].code == ValidationErrorCode.NOT_FOUND
+    assert "ROS2 Control Missing Joint" in val_result.errors[0].title
+    assert builder.robot.get_ros2_control("MissingJointControl") is None

--- a/tests/unit/platforms/blender/test_translator.py
+++ b/tests/unit/platforms/blender/test_translator.py
@@ -1180,7 +1180,7 @@ def test_ros2_control_translator_comprehensive(scene, blender_context):
     item1.state_effort = True
     item1.joint_obj = j1_obj
 
-    # Joint 2 with fallback joint name
+    # Second joint configured with fallback joint name without joint object
     item2 = props.ros2_control_joints.add()
     item2.cmd_position = True
     item2.cmd_velocity = False


### PR DESCRIPTION
# Pull Request

> [!IMPORTANT]
> This project uses **Conventional Commits** and **Release Please** for automated versioning.
> Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat: add lidar sensor`, `fix: core logic bug`).

## 📝 Description
- **Joint Definition Validation**: Added validation in `SceneToRobotTranslator` to catch joints with missing or invalid parent/child links, self-loops, and duplicate child assignments instead of silently omitting them.
- **Orphaned ROS2 Control Handling**: Added an `[ERROR] (Missing)` badge and contextual `TRASH` prune operator to cleanly remove orphaned control items without needing a full scene purge.
- **Documentation**: Documented joint pruning and cleanup workflows in the ROS2 Control Sphinx documentation.

## 🛠️ Type of change
- [x] 🐞 Bug fix (fix)

## ✅ Checklist
- [x] `just test-core` passes (Core unit + integration)
- [x] `just test-unit-blender` passes (Blender unit tests)
- [x] `just pre-commit` passes (format, lint, type checks)
- [x] I have verified the changes manually in the Blender viewport
- [x] I have updated the documentation or verified no changes are needed
